### PR TITLE
feat(nft): /api/ipfs/:cid same-origin proxy for wallet NFT images

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,12 +1,14 @@
 import { Router } from 'express';
 import { healthRoutes } from './health.routes.js';
 import { rpcRoutes } from './rpc.routes.js';
+import { ipfsRouter } from './ipfs.routes.js';
 import appRouter from './app.routes.js';
 
 const router = Router();
 
 router.use('/health', healthRoutes);
 router.use('/api/qrl-rpc', rpcRoutes);
+router.use('/api/ipfs', ipfsRouter);
 router.use('/api', appRouter);
 
 export const routes = router;

--- a/src/routes/ipfs.routes.js
+++ b/src/routes/ipfs.routes.js
@@ -1,0 +1,130 @@
+import { Router } from 'express';
+import rateLimit from 'express-rate-limit';
+import { logger } from '../utils/logger.js';
+
+// Use Node 22's built-in fetch via globalThis so tests can stub it without
+// the ESM-default-export-immutability gymnastics that `node-fetch` requires.
+const fetchImpl = (...args) => globalThis.fetch(...args);
+
+const log = logger.child({ module: 'ipfs-routes' });
+
+/**
+ * Public IPFS gateway used to resolve user-supplied CIDs.
+ * Overridable for self-hosted gateways or staging; defaults to ipfs.io
+ * which is widely available + Cloudflare-fronted.
+ */
+const IPFS_GATEWAY = (process.env.IPFS_GATEWAY || 'https://ipfs.io/ipfs/').replace(/\/?$/, '/');
+const FETCH_TIMEOUT_MS = parseInt(process.env.IPFS_FETCH_TIMEOUT_MS || '8000', 10);
+const MAX_SIZE = parseInt(process.env.IPFS_MAX_SIZE_BYTES || String(10 * 1024 * 1024), 10); // 10 MB
+
+// CIDv0: starts with Qm + 44 base58 chars (no 0, O, I, l)
+const CIDV0_RE = /^Qm[1-9A-HJ-NP-Za-km-z]{44}$/;
+// CIDv1: starts with single multibase prefix; 'b' (base32) is by far the most
+// common. We accept the typical base32 form; other prefixes are rejected to
+// keep the surface tight.
+const CIDV1_RE = /^b[A-Za-z2-7]{58,}$/;
+// After the CID, any number of `/segment` path components are allowed. Path
+// segments may not contain `..`, `\\`, or whitespace.
+const PATH_SEGMENT_RE = /^[A-Za-z0-9._-]+$/;
+
+const ipfsRateLimit = rateLimit({
+  windowMs: 60 * 1000,
+  max: 60, // 60 requests/min/IP — well above expected normal NFT browsing
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'rate-limited' },
+});
+
+function isValidCid(cid) {
+  return CIDV0_RE.test(cid) || CIDV1_RE.test(cid);
+}
+
+function isSafePath(rest) {
+  if (!rest) return true;
+  if (rest.includes('..')) return false;
+  const segments = rest.split('/').filter(Boolean);
+  return segments.every((s) => PATH_SEGMENT_RE.test(s));
+}
+
+const ipfsRouter = Router();
+ipfsRouter.use(ipfsRateLimit);
+
+/**
+ * GET /api/ipfs/:cid             → fetches gateway/<cid>
+ * GET /api/ipfs/:cid/path/to/x   → fetches gateway/<cid>/path/to/x
+ *
+ * Used as a same-origin shim so the wallet's strict
+ * `img-src 'self' data:` CSP can still render IPFS-hosted NFT images
+ * without allowlisting every public gateway, and so JSON metadata
+ * fetches don't depend on the gateway's (often missing) CORS headers.
+ *
+ * The route does NOT accept arbitrary URLs (no `?url=` style proxying)
+ * — that would be a giant SSRF surface. Only well-formed IPFS CIDs are
+ * dereferenced through the configured `IPFS_GATEWAY`.
+ *
+ * Two route patterns share a handler because Express 4's path-to-regexp
+ * won't match `/:cid` against `/:cid/*?` — the optional star modifier still
+ * requires a `/` separator that isn't present when only the CID is supplied.
+ */
+async function ipfsHandler(req, res) {
+  const { cid } = req.params;
+  const rest = req.params[0] || '';
+
+  if (!isValidCid(cid)) {
+    return res.status(400).json({ error: 'invalid CID' });
+  }
+  if (!isSafePath(rest)) {
+    return res.status(400).json({ error: 'invalid path' });
+  }
+
+  const url = `${IPFS_GATEWAY}${cid}${rest ? '/' + rest : ''}`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetchImpl(url, { signal: controller.signal, redirect: 'follow' });
+    if (!response.ok) {
+      log.warn({ cid, status: response.status }, 'IPFS gateway returned non-2xx');
+      return res
+        .status(response.status === 404 ? 404 : 502)
+        .json({ error: 'gateway error', status: response.status });
+    }
+
+    // Reject oversize responses before buffering.
+    const declaredSize = parseInt(response.headers.get('content-length') || '0', 10);
+    if (declaredSize > MAX_SIZE) {
+      return res.status(413).json({ error: 'too large', size: declaredSize, max: MAX_SIZE });
+    }
+
+    const contentType = response.headers.get('content-type') || 'application/octet-stream';
+    const buf = Buffer.from(await response.arrayBuffer());
+    if (buf.length > MAX_SIZE) {
+      return res.status(413).json({ error: 'too large', size: buf.length, max: MAX_SIZE });
+    }
+
+    res.set({
+      'Content-Type': contentType,
+      // IPFS content is content-addressed, so caching for an hour is safe.
+      'Cache-Control': 'public, max-age=3600, immutable',
+      // Sane defaults — never let user-supplied content advertise itself
+      // as the wallet's own scripts.
+      'X-Content-Type-Options': 'nosniff',
+      'Content-Security-Policy': "default-src 'none'; img-src 'self' data: blob:; sandbox",
+    });
+    res.send(buf);
+  } catch (err) {
+    if (err.name === 'AbortError') {
+      log.warn({ cid, rest }, 'IPFS proxy timeout');
+      return res.status(504).json({ error: 'gateway timeout' });
+    }
+    log.error({ err: err.message, url }, 'IPFS proxy failed');
+    return res.status(502).json({ error: 'gateway unreachable' });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+ipfsRouter.get('/:cid', ipfsHandler);
+ipfsRouter.get('/:cid/*', ipfsHandler);
+
+export { ipfsRouter };

--- a/test/routes/ipfs.routes.test.js
+++ b/test/routes/ipfs.routes.test.js
@@ -1,0 +1,148 @@
+import * as chai from 'chai';
+import sinon from 'sinon';
+import { default as chaiHttp, request } from 'chai-http';
+
+chai.use(chaiHttp);
+const { expect } = chai;
+
+import { app } from '../../src/app.js';
+
+function buildFetchResponse({
+  ok = true,
+  status = 200,
+  contentType = 'image/png',
+  body = Buffer.from('PNGDATA'),
+  contentLength,
+} = {}) {
+  const bufBody = body instanceof Buffer ? body : Buffer.from(body);
+  return {
+    ok,
+    status,
+    headers: {
+      get(name) {
+        const n = name.toLowerCase();
+        if (n === 'content-type') return contentType;
+        if (n === 'content-length') return String(contentLength ?? bufBody.length);
+        return null;
+      },
+    },
+    arrayBuffer: async () =>
+      bufBody.buffer.slice(bufBody.byteOffset, bufBody.byteOffset + bufBody.byteLength),
+  };
+}
+
+describe('IPFS Routes', () => {
+  let fetchStub;
+
+  beforeEach(() => {
+    fetchStub = sinon.stub(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('rejects invalid CIDs', async () => {
+    const res = await request.execute(app).get('/api/ipfs/notacid');
+    expect(res).to.have.status(400);
+    expect(res.body.error).to.equal('invalid CID');
+    expect(fetchStub.called).to.equal(false);
+  });
+
+  it('rejects path segments containing ..', async () => {
+    // `..` as its own URL segment gets collapsed by the HTTP-client URL
+    // normalizer before the request hits us, so the only way `..` reaches
+    // the route handler is inside a single segment (e.g. "foo..bar").
+    // Belt-and-suspenders: validate that the handler still rejects this.
+    const res = await request
+      .execute(app)
+      .get('/api/ipfs/QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/foo..bar');
+    expect(res).to.have.status(400);
+    expect(res.body.error).to.equal('invalid path');
+    expect(fetchStub.called).to.equal(false);
+  });
+
+  it('proxies a valid CIDv0 image through the configured gateway', async () => {
+    fetchStub.resolves(
+      buildFetchResponse({ contentType: 'image/png', body: Buffer.from('PNGDATA') }),
+    );
+
+    const cid = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
+    const res = await request.execute(app).get(`/api/ipfs/${cid}`);
+
+    expect(res).to.have.status(200);
+    expect(res).to.have.header('content-type', 'image/png');
+    expect(res).to.have.header('cache-control', /max-age=3600/);
+    expect(res.body).to.be.instanceOf(Buffer);
+    expect(res.body.toString()).to.equal('PNGDATA');
+    expect(fetchStub.calledOnce).to.equal(true);
+    expect(fetchStub.firstCall.args[0]).to.match(new RegExp(`/ipfs/${cid}$`));
+  });
+
+  it('proxies CIDv1 with a path suffix', async () => {
+    fetchStub.resolves(
+      buildFetchResponse({
+        contentType: 'application/json',
+        body: Buffer.from('{"name":"x"}'),
+      }),
+    );
+
+    const cid = 'bafybeib2gp4f5suijuyxbcfhi7lvjzvskyciye5n4ihfrn5pcwhrcq45ru';
+    const res = await request.execute(app).get(`/api/ipfs/${cid}/metadata.json`);
+
+    expect(res).to.have.status(200);
+    expect(res).to.have.header('content-type', /^application\/json/);
+    expect(fetchStub.firstCall.args[0]).to.match(
+      new RegExp(`/ipfs/${cid}/metadata\\.json$`),
+    );
+  });
+
+  it('rejects responses larger than MAX_SIZE', async () => {
+    fetchStub.resolves(
+      buildFetchResponse({ contentLength: 20 * 1024 * 1024, body: Buffer.alloc(8) }),
+    );
+
+    const cid = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
+    const res = await request.execute(app).get(`/api/ipfs/${cid}`);
+
+    expect(res).to.have.status(413);
+    expect(res.body.error).to.equal('too large');
+  });
+
+  it('returns 504 on gateway timeout', async () => {
+    const abortErr = new Error('aborted');
+    abortErr.name = 'AbortError';
+    fetchStub.rejects(abortErr);
+
+    const cid = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
+    const res = await request.execute(app).get(`/api/ipfs/${cid}`);
+
+    expect(res).to.have.status(504);
+    expect(res.body.error).to.equal('gateway timeout');
+  });
+
+  it('returns 502 on generic gateway failure', async () => {
+    fetchStub.rejects(new Error('ECONNRESET'));
+
+    const cid = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
+    const res = await request.execute(app).get(`/api/ipfs/${cid}`);
+
+    expect(res).to.have.status(502);
+    expect(res.body.error).to.equal('gateway unreachable');
+  });
+
+  it('returns 404 when the gateway returns 404', async () => {
+    fetchStub.resolves({
+      ok: false,
+      status: 404,
+      headers: { get: () => null },
+      arrayBuffer: async () => Buffer.alloc(0).buffer,
+    });
+
+    const cid = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
+    const res = await request.execute(app).get(`/api/ipfs/${cid}`);
+
+    expect(res).to.have.status(404);
+    expect(res.body.error).to.equal('gateway error');
+  });
+});


### PR DESCRIPTION
## Summary

Adds `GET /api/ipfs/:cid` to the backend so the wallet can resolve IPFS-hosted NFT images and metadata through its own origin. Needed because the wallet's deployed CSP is `img-src 'self' data:` — strict on purpose, but it blocks every public IPFS gateway, which means real NFTs minted to IPFS don't render today.

Pair with the frontend change at DigitalGuards/myqrlwallet-frontend#TBD.

## Behaviour

- `GET /api/ipfs/:cid` → fetches `${IPFS_GATEWAY}<cid>` and streams the bytes back.
- `GET /api/ipfs/:cid/path/to/x` → fetches `${IPFS_GATEWAY}<cid>/path/to/x`.
- CIDv0 (`Qm` + 44 base58) and CIDv1 (`b` + 58+ base32) are regex-validated.
- Path segments validated against `[A-Za-z0-9._-]+`; `..` rejected defense-in-depth (HTTP clients normally collapse it before sending).
- 8 s `AbortController` timeout, 10 MB body cap (declared `Content-Length` + final buffer check), 60 req/min/IP rate limit.
- `Cache-Control: public, max-age=3600, immutable` — IPFS content is content-addressed so this is trivially safe.
- Responses also set `X-Content-Type-Options: nosniff` and an isolating CSP, so a malicious image MIME-typed as HTML can't escape into the wallet's origin context.

## Why this, not an `?url=` proxy

`?url=<arbitrary>` would be a giant SSRF surface even with allowlists. This route accepts **only** well-formed CIDs and dereferences them through the configured `IPFS_GATEWAY`. The gateway URL is the trust boundary.

## Config

- `IPFS_GATEWAY` (default `https://ipfs.io/ipfs/`) — the upstream public gateway.
- `IPFS_FETCH_TIMEOUT_MS` (default `8000`)
- `IPFS_MAX_SIZE_BYTES` (default `10485760` = 10 MB)

## Test plan

- [x] `npm run format:check` clean
- [x] `npm run lint` clean
- [x] `npm test` — 67 tests, all green (added 8 covering the new route: invalid CID, path traversal, CIDv0 ok, CIDv1 ok, oversize rejected, 504 timeout, 502 generic failure, 404 passthrough)
- [ ] After deploy to dev: `curl -sI https://dev.qrlwallet.com/api/ipfs/QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG` should return 200 with the file content-type.
- [ ] Wallet on dev.qrlwallet.com: add an IPFS-hosted NFT, image renders without CSP errors in DevTools.

## Risks

- The proxy is a thin layer over `ipfs.io`. If ipfs.io is unreachable, the wallet falls back to the placeholder image (same UX as today). Configurable gateway lets ops swap to a self-hosted node later.
- 60 req/min/IP is generous for normal NFT browsing but bots could still pin a useless cache miss. Cache-Control + browser caching mitigates.
- Uses Node 22's built-in `globalThis.fetch` — not Node 18-compatible. Backend deploy already runs on Node 22 per CLAUDE.md, so this is consistent.

## Follow-ups (not in this PR)

- Wallet CSP relaxation for non-IPFS NFT images (e.g. Arweave, HTTPS CDNs) — flagged in memory as a separate small nginx config change.
- Optional: backend in-memory cache via `node-cache` if Cloudflare/Nginx caching proves insufficient.