### PR TITLE
fix(ipfs): stream-and-cap to close OOM window flagged on #41

### DIFF
--- a/src/routes/ipfs.routes.js
+++ b/src/routes/ipfs.routes.js
@@ -90,17 +90,44 @@ async function ipfsHandler(req, res) {
         .json({ error: 'gateway error', status: response.status });
     }
 
-    // Reject oversize responses before buffering.
+    // Reject oversize responses up front if the gateway is honest about
+    // Content-Length. A malicious or buggy gateway can still under-declare
+    // (or omit) the header and stream arbitrarily many bytes, so we ALSO
+    // enforce the cap incrementally as we read the body — never let an
+    // attacker buffer >MAX_SIZE into our heap.
     const declaredSize = parseInt(response.headers.get('content-length') || '0', 10);
     if (declaredSize > MAX_SIZE) {
       return res.status(413).json({ error: 'too large', size: declaredSize, max: MAX_SIZE });
     }
 
     const contentType = response.headers.get('content-type') || 'application/octet-stream';
-    const buf = Buffer.from(await response.arrayBuffer());
-    if (buf.length > MAX_SIZE) {
-      return res.status(413).json({ error: 'too large', size: buf.length, max: MAX_SIZE });
+
+    const reader = response.body.getReader();
+    const chunks = [];
+    let received = 0;
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        received += value.byteLength;
+        if (received > MAX_SIZE) {
+          // Stop pulling bytes off the gateway socket before we ever
+          // commit them to our heap. cancel() may reject if the stream
+          // is already closed — swallow that.
+          try {
+            await reader.cancel();
+          } catch {
+            /* noop */
+          }
+          return res.status(413).json({ error: 'too large', size: received, max: MAX_SIZE });
+        }
+        chunks.push(value);
+      }
+    } catch (streamErr) {
+      log.error({ err: streamErr.message, url }, 'IPFS proxy stream read failed');
+      return res.status(502).json({ error: 'gateway stream error' });
     }
+    const buf = Buffer.concat(chunks.map((c) => Buffer.from(c)));
 
     res.set({
       'Content-Type': contentType,

--- a/test/routes/ipfs.routes.test.js
+++ b/test/routes/ipfs.routes.test.js
@@ -7,14 +7,31 @@ const { expect } = chai;
 
 import { app } from '../../src/app.js';
 
+/**
+ * Build a stand-in for the Fetch API Response object that lets us drive
+ * the streaming read loop in ipfs.routes.js. `chunks` is an array of
+ * Uint8Array / Buffer pieces emitted in order.
+ */
 function buildFetchResponse({
   ok = true,
   status = 200,
   contentType = 'image/png',
-  body = Buffer.from('PNGDATA'),
   contentLength,
+  chunks = [Buffer.from('PNGDATA')],
 } = {}) {
-  const bufBody = body instanceof Buffer ? body : Buffer.from(body);
+  const queue = chunks.map((c) => (c instanceof Uint8Array ? c : Buffer.from(c)));
+  const totalLen = queue.reduce((n, c) => n + c.byteLength, 0);
+  let i = 0;
+  const reader = {
+    async read() {
+      if (i >= queue.length) return { done: true, value: undefined };
+      const value = queue[i++];
+      return { done: false, value };
+    },
+    async cancel() {
+      i = queue.length;
+    },
+  };
   return {
     ok,
     status,
@@ -22,12 +39,11 @@ function buildFetchResponse({
       get(name) {
         const n = name.toLowerCase();
         if (n === 'content-type') return contentType;
-        if (n === 'content-length') return String(contentLength ?? bufBody.length);
+        if (n === 'content-length') return String(contentLength ?? totalLen);
         return null;
       },
     },
-    arrayBuffer: async () =>
-      bufBody.buffer.slice(bufBody.byteOffset, bufBody.byteOffset + bufBody.byteLength),
+    body: { getReader: () => reader },
   };
 }
 
@@ -64,7 +80,7 @@ describe('IPFS Routes', () => {
 
   it('proxies a valid CIDv0 image through the configured gateway', async () => {
     fetchStub.resolves(
-      buildFetchResponse({ contentType: 'image/png', body: Buffer.from('PNGDATA') }),
+      buildFetchResponse({ contentType: 'image/png', chunks: [Buffer.from('PNGDATA')] }),
     );
 
     const cid = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
@@ -83,7 +99,7 @@ describe('IPFS Routes', () => {
     fetchStub.resolves(
       buildFetchResponse({
         contentType: 'application/json',
-        body: Buffer.from('{"name":"x"}'),
+        chunks: [Buffer.from('{"name":"x"}')],
       }),
     );
 
@@ -97,9 +113,9 @@ describe('IPFS Routes', () => {
     );
   });
 
-  it('rejects responses larger than MAX_SIZE', async () => {
+  it('rejects oversize responses up front via declared Content-Length', async () => {
     fetchStub.resolves(
-      buildFetchResponse({ contentLength: 20 * 1024 * 1024, body: Buffer.alloc(8) }),
+      buildFetchResponse({ contentLength: 20 * 1024 * 1024, chunks: [Buffer.alloc(8)] }),
     );
 
     const cid = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
@@ -107,6 +123,26 @@ describe('IPFS Routes', () => {
 
     expect(res).to.have.status(413);
     expect(res.body.error).to.equal('too large');
+  });
+
+  it('rejects oversize responses mid-stream even when Content-Length lies', async () => {
+    // Gateway lies in the header (says 10 bytes) but actually streams 12 MB
+    // in 1 MB chunks. The handler must trip the incremental cap and 413
+    // instead of buffering the whole thing into memory.
+    const oneMb = Buffer.alloc(1024 * 1024);
+    fetchStub.resolves(
+      buildFetchResponse({
+        contentLength: 10,
+        chunks: Array(12).fill(oneMb),
+      }),
+    );
+
+    const cid = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
+    const res = await request.execute(app).get(`/api/ipfs/${cid}`);
+
+    expect(res).to.have.status(413);
+    expect(res.body.error).to.equal('too large');
+    expect(res.body.size).to.be.greaterThan(10 * 1024 * 1024);
   });
 
   it('returns 504 on gateway timeout', async () => {
@@ -131,12 +167,42 @@ describe('IPFS Routes', () => {
     expect(res.body.error).to.equal('gateway unreachable');
   });
 
+  it('returns 502 when the body stream throws mid-read', async () => {
+    fetchStub.resolves({
+      ok: true,
+      status: 200,
+      headers: {
+        get(name) {
+          const n = name.toLowerCase();
+          if (n === 'content-type') return 'image/png';
+          if (n === 'content-length') return '100';
+          return null;
+        },
+      },
+      body: {
+        getReader() {
+          return {
+            async read() {
+              throw new Error('socket hang up');
+            },
+            async cancel() {},
+          };
+        },
+      },
+    });
+
+    const cid = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
+    const res = await request.execute(app).get(`/api/ipfs/${cid}`);
+
+    expect(res).to.have.status(502);
+    expect(res.body.error).to.equal('gateway stream error');
+  });
+
   it('returns 404 when the gateway returns 404', async () => {
     fetchStub.resolves({
       ok: false,
       status: 404,
       headers: { get: () => null },
-      arrayBuffer: async () => Buffer.alloc(0).buffer,
     });
 
     const cid = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';


### PR DESCRIPTION
## Summary

Addresses gemini-code-assist's review on #41: the IPFS proxy buffered the whole gateway response via `await response.arrayBuffer()` before checking size. A malicious or buggy gateway that under-declares (or omits) Content-Length could stream arbitrarily many bytes, all of which we'd commit to the heap before the size check could fire. With 60 req/min/IP from multiple IPs that's a real DoS / OOM surface.

## Change

`response.body.getReader()` streaming loop with per-chunk accumulator:
- Read chunks into an array, sum `received += value.byteLength` on each.
- The moment `received > MAX_SIZE`, call `reader.cancel()` to stop pulling bytes off the gateway socket, then 413.
- The on-disk-size check via declared `Content-Length` stays as a fast-path reject for honest gateways.

Adds a new 502 path (`gateway stream error`) for mid-read socket failures.

## Tests

Two new cases:
1. Gateway lies about Content-Length (says 10 bytes) but actually emits 12 × 1MB chunks → must 413 mid-stream, not OOM.
2. `reader.read()` throws mid-stream → 502 `gateway stream error`.

`npm test`: 69 passing (was 67).
`npm run lint` + `format:check` clean.

## Risk

- Behaviour change for legitimate < MAX_SIZE responses: bytes flow chunk-by-chunk into an array, then `Buffer.concat` at the end. Same final memory footprint as `arrayBuffer()` but earlier abort on overrun.
- No change to the public API surface or headers.