### PR TITLE
fix(ipfs): null body + AbortError + Buffer.concat (Gemini #42 follow-ups)

### DIFF
--- a/src/routes/ipfs.routes.js
+++ b/src/routes/ipfs.routes.js
@@ -102,6 +102,14 @@ async function ipfsHandler(req, res) {
 
     const contentType = response.headers.get('content-type') || 'application/octet-stream';
 
+    // Fetch API allows response.body to be null (e.g. 204 No Content). Without
+    // an explicit check, the .getReader() call below would throw a TypeError
+    // that we'd report as "gateway unreachable" — misleading.
+    if (!response.body) {
+      log.warn({ cid, status: response.status }, 'IPFS gateway returned empty body');
+      return res.status(502).json({ error: 'gateway error' });
+    }
+
     const reader = response.body.getReader();
     const chunks = [];
     let received = 0;
@@ -124,10 +132,16 @@ async function ipfsHandler(req, res) {
         chunks.push(value);
       }
     } catch (streamErr) {
+      // An AbortError mid-stream is the FETCH_TIMEOUT_MS controller firing,
+      // not a stream-specific failure. Re-throw so the outer catch maps it
+      // to 504 like the pre-streaming code did. Anything else stays a 502.
+      if (streamErr.name === 'AbortError') throw streamErr;
       log.error({ err: streamErr.message, url }, 'IPFS proxy stream read failed');
       return res.status(502).json({ error: 'gateway stream error' });
     }
-    const buf = Buffer.concat(chunks.map((c) => Buffer.from(c)));
+    // Buffer.concat accepts Uint8Array chunks directly; the previous
+    // .map(Buffer.from) was wasted work in a hot path.
+    const buf = Buffer.concat(chunks);
 
     res.set({
       'Content-Type': contentType,

--- a/src/routes/ipfs.routes.js
+++ b/src/routes/ipfs.routes.js
@@ -136,7 +136,7 @@ async function ipfsHandler(req, res) {
       // not a stream-specific failure. Re-throw so the outer catch maps it
       // to 504 like the pre-streaming code did. Anything else stays a 502.
       if (streamErr.name === 'AbortError') throw streamErr;
-      log.error({ err: streamErr.message, url }, 'IPFS proxy stream read failed');
+      log.error({ err: streamErr, url }, 'IPFS proxy stream read failed');
       return res.status(502).json({ error: 'gateway stream error' });
     }
     // Buffer.concat accepts Uint8Array chunks directly; the previous

--- a/test/routes/ipfs.routes.test.js
+++ b/test/routes/ipfs.routes.test.js
@@ -167,6 +167,66 @@ describe('IPFS Routes', () => {
     expect(res.body.error).to.equal('gateway unreachable');
   });
 
+  it('returns 502 when the gateway response has a null body', async () => {
+    // Fetch API allows null body (e.g. 204 No Content). Handler must surface
+    // this as a clean gateway error rather than letting .getReader() blow up.
+    fetchStub.resolves({
+      ok: true,
+      status: 200,
+      headers: {
+        get(name) {
+          const n = name.toLowerCase();
+          if (n === 'content-type') return 'image/png';
+          if (n === 'content-length') return '0';
+          return null;
+        },
+      },
+      body: null,
+    });
+
+    const cid = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
+    const res = await request.execute(app).get(`/api/ipfs/${cid}`);
+
+    expect(res).to.have.status(502);
+    expect(res.body.error).to.equal('gateway error');
+  });
+
+  it('returns 504 when an AbortError fires during stream read', async () => {
+    // FETCH_TIMEOUT_MS controller can fire AFTER the response headers are
+    // received — the inner stream-read catch must re-throw AbortError so
+    // the outer catch maps it to 504, not the generic 502 stream error.
+    const abortErr = new Error('aborted mid-stream');
+    abortErr.name = 'AbortError';
+    fetchStub.resolves({
+      ok: true,
+      status: 200,
+      headers: {
+        get(name) {
+          const n = name.toLowerCase();
+          if (n === 'content-type') return 'image/png';
+          if (n === 'content-length') return '1000';
+          return null;
+        },
+      },
+      body: {
+        getReader() {
+          return {
+            async read() {
+              throw abortErr;
+            },
+            async cancel() {},
+          };
+        },
+      },
+    });
+
+    const cid = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
+    const res = await request.execute(app).get(`/api/ipfs/${cid}`);
+
+    expect(res).to.have.status(504);
+    expect(res.body.error).to.equal('gateway timeout');
+  });
+
   it('returns 502 when the body stream throws mid-read', async () => {
     fetchStub.resolves({
       ok: true,


### PR DESCRIPTION
## Summary

Three medium-priority follow-ups Gemini left on the (already-merged) streaming-size-cap PR #42.

### 1. Null \`response.body\` check

Fetch API spec allows \`response.body\` to be null (e.g. 204 No Content). The current code calls \`.getReader()\` unconditionally — TypeError gets caught by the outer block and returned as 'gateway unreachable', which is misleading. Add an explicit null check that returns 502 'gateway error' with a log line.

### 2. AbortError re-throw from inner catch

\`FETCH_TIMEOUT_MS\` AbortController can fire AFTER the response headers come back but mid-body. In that case \`reader.read()\` throws an AbortError that the inner catch was labelling as 502 'gateway stream error', bypassing the outer 504 'gateway timeout' path. Re-throw AbortError from the inner catch so timeouts during streaming are reported consistently.

### 3. Drop redundant \`Buffer.from\` in concat

\`Buffer.concat\` natively accepts Uint8Array chunks; the previous \`.map(c => Buffer.from(c))\` was wasted allocation in a hot path. One-line cleanup.

## Tests

Two new cases:
- Null body → 502 'gateway error'
- AbortError mid-stream → 504 'gateway timeout' (not 502)

Total: 71 passing, lint + format:check clean.

## Risk

Behaviour change is strictly more accurate error codes; no regression to existing happy / error paths.