### PR TITLE
chore: remove custom RPC endpoint support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ If rules conflict, follow the highest item.
 | `server.js` | Process entry: HTTP server + Socket.IO relay + healthMonitor lifecycle + Prometheus `/metrics` endpoint (token-protected). |
 | `src/app.js` | Express app wiring (CORS, JSON, routes, error handler). Imported by `server.js` and tests. |
 | `src/config/index.js` | dotenv-loaded config singleton. **Endpoint resolution** (`RPC_ENDPOINTS_<NETWORK>` comma-list, back-compat to `RPC_ENDPOINT_<NETWORK>`) lives here. Add tunables to `RPC_HEALTH.*`. |
-| `src/services/rpc.service.js` | RPC proxy: cache for invariant methods, SSRF-validated `custom` RPC, primary-only routing for `txpool_*` / `debug_*` / `admin_*`, `AbortController`-bounded fetch. |
+| `src/services/rpc.service.js` | RPC proxy: cache for invariant methods, primary-only routing for `txpool_*` / `debug_*` / `admin_*`, `AbortController`-bounded fetch. |
 | `src/services/rpc/healthMonitor.js` | Per-endpoint state machine (`up` / `down` / `stalled` / `unknown`). Background poller (default 10 s) issues `qrl_blockNumber` against each endpoint. Passive signals come from real request results. |
 | `src/services/notifier.js` | Single integration seam for ops alerting. Currently emits structured logs only — add Discord/Telegram/Sentry here, not at call sites. |
 | `src/middleware/rpc-security.js` | Method whitelist, batch reject, request-size limit, two-tier rate limit (read vs write). Source of truth for what's exposed via the proxy. |
@@ -103,9 +103,6 @@ When ops adds a new failover entry, it's an env edit + pm2 restart, not a code c
 
 ### Health-state semantics
 `healthMonitor` distinguishes `up` / `down` / `stalled` / `unknown`. Stall is detected by the **background poller** (block height unchanged for `RPC_STALL_AFTER_MS`, default 5 min). Strictly-increasing block height is required to count as forward progress; reorgs/regressions do not reset the stall timer and emit a `height-regression` notifier event. Real wallet requests update health state passively via `recordRequestResult` and can flip `unknown → up` immediately on success.
-
-### Custom RPC SSRF guard
-`validateCustomRpcUrl` (in `rpc.service.js`) is the SSRF perimeter for the `custom` network path. It currently blocks: localhost, RFC-1918, link-local (169.254/16), reserved 0/8, IPv6 `::1`. **Known gaps** worth a dedicated security pass before promoting `custom` to a more user-facing flow: CGNAT (100.64/10), IETF Protocol Assignments (192.0.0/24), benchmark (198.18/15), IPv6 ULA (`fc00::/7`), IPv6 link-local (`fe80::/10`), invalid octet ranges, and DNS rebinding (host that resolves to a private IP). Changes to this function are security-critical — keep tests around it.
 
 ### dApp Connect canonical behaviour
 The relay protocol contract — handshake idempotency, channel rotation, participant types, stale-session cleanup — lives in the workspace-root CLAUDE.md §4. Read that section before touching `src/relay/`. A regression in the dApp Connect surface is high-priority because it ships in mobile + web wallets that may be many days out of date.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The backend provides two main services:
 
 ### 1. RPC Proxy (`POST /api/qrl-rpc/:network`)
 - Routes JSON-RPC calls to QRL blockchain nodes
-- Supports testnet, mainnet, and custom RPC endpoints
+- Supports testnet and mainnet RPC endpoints
 - Response caching via node-cache
 - CORS handling for browser requests
 
@@ -63,7 +63,7 @@ npm test        # Run tests
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| POST | `/api/qrl-rpc/:network` | Proxy RPC calls (network: testnet, mainnet, custom) |
+| POST | `/api/qrl-rpc/:network` | Proxy RPC calls (network: testnet, mainnet) |
 | POST | `/api/tx-history` | Get transaction history for address |
 | GET | `/health` | Health check |
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -41,7 +41,6 @@ export const CONFIG = {
     dev: parseEndpointList('DEV', ['http://localhost:8545']),
     testnet: parseEndpointList('TESTNET', ['http://localhost:8545']),
     mainnet: parseEndpointList('MAINNET', ['http://localhost:8545']),
-    custom: 'CUSTOM_RPC_URL',
   },
 
   RPC_HEALTH: {

--- a/src/routes/rpc.routes.js
+++ b/src/routes/rpc.routes.js
@@ -61,9 +61,7 @@ router.post(
       const { network } = req.params;
       const { method, params } = req.body;
 
-      let { customRpcUrl } = req.query;
-
-      const result = await rpcService.executeRPC(network, method, params, customRpcUrl);
+      const result = await rpcService.executeRPC(network, method, params);
       res.json(result);
     } catch (error) {
       next(error);

--- a/src/services/rpc.service.js
+++ b/src/services/rpc.service.js
@@ -28,54 +28,6 @@ function isPrimaryOnlyMethod(method) {
   return PRIMARY_ONLY_PREFIXES.some((p) => method.startsWith(p));
 }
 
-/**
- * Validate a custom RPC URL to prevent SSRF attacks.
- * Blocks private IP ranges, localhost, cloud metadata endpoints, and non-HTTP protocols.
- */
-function validateCustomRpcUrl(url) {
-  let parsed;
-  try {
-    parsed = new URL(url);
-  } catch {
-    throw new Error('Invalid custom RPC URL format');
-  }
-
-  if (!['http:', 'https:'].includes(parsed.protocol)) {
-    throw new Error('Custom RPC URL must use http or https protocol');
-  }
-
-  const hostname = parsed.hostname.replace(/^\[|\]$/g, '').toLowerCase();
-
-  // Block IPv6 localhost
-  if (hostname === '::1' || hostname === '0:0:0:0:0:0:0:1') {
-    throw new Error('Custom RPC URL cannot target localhost');
-  }
-
-  // Block localhost hostnames
-  if (hostname === 'localhost' || hostname.endsWith('.localhost')) {
-    throw new Error('Custom RPC URL cannot target localhost');
-  }
-
-  // Block cloud metadata hostnames
-  if (hostname === 'metadata.google.internal') {
-    throw new Error('Custom RPC URL cannot target internal services');
-  }
-
-  // Block private/reserved IPv4 ranges
-  const ipv4Match = hostname.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
-  if (ipv4Match) {
-    const [a, b] = [Number(ipv4Match[1]), Number(ipv4Match[2])];
-    if (a === 0) throw new Error('Custom RPC URL cannot target reserved addresses');
-    if (a === 127) throw new Error('Custom RPC URL cannot target localhost');
-    if (a === 10) throw new Error('Custom RPC URL cannot target private networks');
-    if (a === 172 && b >= 16 && b <= 31)
-      throw new Error('Custom RPC URL cannot target private networks');
-    if (a === 192 && b === 168) throw new Error('Custom RPC URL cannot target private networks');
-    if (a === 169 && b === 254)
-      throw new Error('Custom RPC URL cannot target link-local addresses');
-  }
-}
-
 class RPCService {
   async makeRPCCall(endpoint, method, params) {
     const controller = new AbortController();
@@ -105,16 +57,8 @@ class RPCService {
     }
   }
 
-  async executeRPC(network, method, params, customRpcUrl = '') {
+  async executeRPC(network, method, params) {
     if (!CONFIG.RPC_ENDPOINTS[network]) {
-      throw new Error('Invalid network');
-    }
-
-    if (network === 'custom') {
-      if (customRpcUrl !== '') {
-        validateCustomRpcUrl(customRpcUrl);
-        return await this.makeRPCCall(customRpcUrl, method, params);
-      }
       throw new Error('Invalid network');
     }
 

--- a/src/services/rpc/healthMonitor.js
+++ b/src/services/rpc/healthMonitor.js
@@ -40,7 +40,6 @@ class HealthMonitor {
   init() {
     if (this.initialised) return;
     for (const [network, endpoints] of Object.entries(CONFIG.RPC_ENDPOINTS)) {
-      if (network === 'custom') continue;
       if (!Array.isArray(endpoints) || endpoints.length === 0) continue;
       this.networks.set(network, endpoints.map(makeEndpointRecord));
     }

--- a/test/services/rpc.service.test.js
+++ b/test/services/rpc.service.test.js
@@ -42,7 +42,7 @@ describe('RPC Service', () => {
     expect(CONFIG.RPC_ENDPOINTS).to.have.property('dev');
     expect(CONFIG.RPC_ENDPOINTS).to.have.property('testnet');
     expect(CONFIG.RPC_ENDPOINTS).to.have.property('mainnet');
-    expect(CONFIG.RPC_ENDPOINTS).to.have.property('custom');
+    expect(CONFIG.RPC_ENDPOINTS).to.not.have.property('custom');
   });
 
   describe('caching behavior', () => {


### PR DESCRIPTION
## Summary

Permanently remove the user-supplied custom-RPC code path from the proxy. The proxy now serves only the operator-configured networks (dev, testnet, mainnet) and rejects `/api/qrl-rpc/custom` as `Invalid network`. Paired with the frontend removal in DigitalGuards/myqrlwallet-frontend#149.

## Removed

- `custom: 'CUSTOM_RPC_URL'` entry in `CONFIG.RPC_ENDPOINTS` (`src/config/index.js`).
- `customRpcUrl` query-string handling in `src/routes/rpc.routes.js`.
- The `network === 'custom'` branch in `rpcService.executeRPC` and the now-unused `customRpcUrl` parameter (`src/services/rpc.service.js`).
- `validateCustomRpcUrl` SSRF guard (no longer reachable after the branch above is gone).
- `if (network === 'custom') continue;` skip in `healthMonitor.init` (obsolete, no `custom` entry remains).
- "Custom RPC SSRF guard" section in `CLAUDE.md` and "custom RPC" wording in the high-signal map row + `README.md`.

The matching test `should have valid RPC endpoints configured` now asserts `RPC_ENDPOINTS` does NOT carry a `custom` key.

## Files touched

```
 CLAUDE.md                         |  5 +---
 README.md                         |  4 +--
 src/config/index.js               |  1 -
 src/routes/rpc.routes.js          |  4 +--
 src/services/rpc.service.js       | 58 +--------------------------------------
 src/services/rpc/healthMonitor.js |  1 -
 test/services/rpc.service.test.js |  2 +-
 7 files changed, 6 insertions(+), 69 deletions(-)
```

## Intentionally preserved

- Mainnet / testnet / dev network routing.
- `RPC_ENDPOINTS_<NETWORK>` (and legacy single-URL `RPC_ENDPOINT_<NETWORK>`) operator failover env vars in `src/config/index.js`. These are operator infra, not user-facing custom RPC.
- `/health` per-endpoint snapshot and the entire `healthMonitor` state machine.
- All security middleware (method whitelist, rate limits, request size limit, batch reject) and the cache whitelist.
- dApp Connect relay (`src/relay/*`).

## Validation

- `npm run format:check`: pass ("All matched files use Prettier code style!").
- `npm run lint`: pass.
- `npm test`: pass (71 passing).
- `typecheck`: not defined (plain JS, per repo CLAUDE.md).
- `build`: not defined (plain JS, per repo CLAUDE.md).

## Test plan

- [ ] After deploy, confirm `POST /api/qrl-rpc/custom` returns `{"error":"Invalid network"}` (was previously a backdoor to any URL given as `?customRpcUrl=`).
- [ ] Confirm `POST /api/qrl-rpc/testnet` and `/mainnet` continue to proxy `qrl_blockNumber` etc.
- [ ] Confirm `GET /health` still returns the per-endpoint snapshot for `testnet` / `mainnet` / `dev` and no longer mentions `custom`.