### PR TITLE
release: dev → main (NFT IPFS proxy, scalability sprint-1, custom-RPC removal)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ If rules conflict, follow the highest item.
 | `server.js` | Process entry: HTTP server + Socket.IO relay + healthMonitor lifecycle + Prometheus `/metrics` endpoint (token-protected). |
 | `src/app.js` | Express app wiring (CORS, JSON, routes, error handler). Imported by `server.js` and tests. |
 | `src/config/index.js` | dotenv-loaded config singleton. **Endpoint resolution** (`RPC_ENDPOINTS_<NETWORK>` comma-list, back-compat to `RPC_ENDPOINT_<NETWORK>`) lives here. Add tunables to `RPC_HEALTH.*`. |
-| `src/services/rpc.service.js` | RPC proxy: cache for invariant methods, SSRF-validated `custom` RPC, primary-only routing for `txpool_*` / `debug_*` / `admin_*`, `AbortController`-bounded fetch. |
+| `src/services/rpc.service.js` | RPC proxy: cache for invariant methods, primary-only routing for `txpool_*` / `debug_*` / `admin_*`, `AbortController`-bounded fetch. |
 | `src/services/rpc/healthMonitor.js` | Per-endpoint state machine (`up` / `down` / `stalled` / `unknown`). Background poller (default 10 s) issues `qrl_blockNumber` against each endpoint. Passive signals come from real request results. |
 | `src/services/notifier.js` | Single integration seam for ops alerting. Currently emits structured logs only — add Discord/Telegram/Sentry here, not at call sites. |
 | `src/middleware/rpc-security.js` | Method whitelist, batch reject, request-size limit, two-tier rate limit (read vs write). Source of truth for what's exposed via the proxy. |
@@ -103,9 +103,6 @@ When ops adds a new failover entry, it's an env edit + pm2 restart, not a code c
 
 ### Health-state semantics
 `healthMonitor` distinguishes `up` / `down` / `stalled` / `unknown`. Stall is detected by the **background poller** (block height unchanged for `RPC_STALL_AFTER_MS`, default 5 min). Strictly-increasing block height is required to count as forward progress; reorgs/regressions do not reset the stall timer and emit a `height-regression` notifier event. Real wallet requests update health state passively via `recordRequestResult` and can flip `unknown → up` immediately on success.
-
-### Custom RPC SSRF guard
-`validateCustomRpcUrl` (in `rpc.service.js`) is the SSRF perimeter for the `custom` network path. It currently blocks: localhost, RFC-1918, link-local (169.254/16), reserved 0/8, IPv6 `::1`. **Known gaps** worth a dedicated security pass before promoting `custom` to a more user-facing flow: CGNAT (100.64/10), IETF Protocol Assignments (192.0.0/24), benchmark (198.18/15), IPv6 ULA (`fc00::/7`), IPv6 link-local (`fe80::/10`), invalid octet ranges, and DNS rebinding (host that resolves to a private IP). Changes to this function are security-critical — keep tests around it.
 
 ### dApp Connect canonical behaviour
 The relay protocol contract — handshake idempotency, channel rotation, participant types, stale-session cleanup — lives in the workspace-root CLAUDE.md §4. Read that section before touching `src/relay/`. A regression in the dApp Connect surface is high-priority because it ships in mobile + web wallets that may be many days out of date.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The backend provides two main services:
 
 ### 1. RPC Proxy (`POST /api/qrl-rpc/:network`)
 - Routes JSON-RPC calls to QRL blockchain nodes
-- Supports testnet, mainnet, and custom RPC endpoints
+- Supports testnet and mainnet RPC endpoints
 - Response caching via node-cache
 - CORS handling for browser requests
 
@@ -63,7 +63,7 @@ npm test        # Run tests
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| POST | `/api/qrl-rpc/:network` | Proxy RPC calls (network: testnet, mainnet, custom) |
+| POST | `/api/qrl-rpc/:network` | Proxy RPC calls (network: testnet, mainnet) |
 | POST | `/api/tx-history` | Get transaction history for address |
 | GET | `/health` | Health check |
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -41,7 +41,6 @@ export const CONFIG = {
     dev: parseEndpointList('DEV', ['http://localhost:8545']),
     testnet: parseEndpointList('TESTNET', ['http://localhost:8545']),
     mainnet: parseEndpointList('MAINNET', ['http://localhost:8545']),
-    custom: 'CUSTOM_RPC_URL',
   },
 
   RPC_HEALTH: {

--- a/src/middleware/rpc-security.js
+++ b/src/middleware/rpc-security.js
@@ -281,11 +281,13 @@ export const rpcParamsValidator = (req, res, next) => {
         // the genesis check above still covers the worst case.
       }
 
-      // Address filter: reject 0x-prefixed addresses outright. Per QRL v2
-      // protocol rules addresses are Q-prefixed; a 0x-prefixed value here
-      // is either malformed or an attempt to slip Ethereum-style input
-      // through the proxy. Also cap array length so a single request
-      // can't fan out into N parallel address lookups on the node.
+      // Address filter: require the canonical QRL v2 form (Q + 40 hex
+      // chars). Previously we only rejected 0x-prefixed inputs, which let
+      // arbitrary malformed strings (truncated addresses, wrong-prefix
+      // strings, whitespace) through to the node — same validation as
+      // qrl_getCode / qrl_getBalance elsewhere in this middleware. Also
+      // cap array length so a single request can't fan out into N
+      // parallel address lookups on the node.
       if (filter.address !== undefined && filter.address !== null) {
         const addrs = Array.isArray(filter.address) ? filter.address : [filter.address];
         if (addrs.length > MAX_GETLOGS_ADDRESSES) {
@@ -298,13 +300,13 @@ export const rpcParamsValidator = (req, res, next) => {
           );
         }
         for (const a of addrs) {
-          if (typeof a === 'string' && a.startsWith('0x')) {
+          if (typeof a !== 'string' || !/^Q[a-fA-F0-9]{40}$/i.test(a)) {
             return sendRpcError(
               res,
               400,
               id,
               -32602,
-              'Invalid params: QRL addresses must be Q-prefixed'
+              'Invalid params: QRL addresses must match Q + 40 hex chars'
             );
           }
         }

--- a/src/middleware/rpc-security.js
+++ b/src/middleware/rpc-security.js
@@ -38,6 +38,24 @@ const ALLOWED_RPC_METHODS = new Set([
 const WRITE_METHODS = new Set(['qrl_sendRawTransaction', 'qrl_sendTransaction']);
 
 /**
+ * qrl_getLogs bounds. Without these a single request can ask the node to
+ * scan the whole chain, monopolising RPC capacity for everyone else.
+ */
+const MAX_GETLOGS_BLOCK_RANGE = 5000; // ~16-17 hours of QRL Zond blocks
+const MAX_GETLOGS_ADDRESSES = 10;
+
+/**
+ * Parse a hex block tag to a Number, or null for named tags / invalid input.
+ */
+const parseBlockTag = (v) => {
+  if (typeof v !== 'string') return null;
+  if (v === 'latest' || v === 'pending' || v === 'earliest') return null;
+  if (!v.startsWith('0x')) return null;
+  const n = parseInt(v, 16);
+  return Number.isFinite(n) ? n : null;
+};
+
+/**
  * Helper function to send JSON-RPC error responses
  */
 const sendRpcError = (res, statusCode, id, errorCode, message) => {
@@ -214,6 +232,59 @@ export const rpcParamsValidator = (req, res, next) => {
         return sendRpcError(res, 400, id, -32602, 'Invalid params: transaction object required');
       }
       break;
+
+    case 'qrl_getLogs': {
+      // Bound the request before proxying — otherwise a caller can ask the
+      // node to scan from genesis to tip, blocking the RPC for everyone
+      // else for seconds. blockHash form (single-block) is always fine.
+      if (!params || params.length < 1 || typeof params[0] !== 'object' || params[0] === null) {
+        return sendRpcError(res, 400, id, -32602, 'Invalid params: filter object required');
+      }
+      const filter = params[0];
+
+      if (typeof filter.blockHash !== 'string') {
+        // Open-ended scans from genesis are never legitimate from this proxy.
+        if (filter.fromBlock === 'earliest' || filter.fromBlock === '0x0') {
+          return sendRpcError(
+            res,
+            400,
+            id,
+            -32602,
+            'Invalid params: qrl_getLogs from genesis is not allowed; supply a recent fromBlock'
+          );
+        }
+
+        const from = parseBlockTag(filter.fromBlock);
+        const to = parseBlockTag(filter.toBlock);
+        // Both sides numeric → enforce the range cap directly.
+        if (from !== null && to !== null) {
+          const range = to - from;
+          if (range < 0 || range > MAX_GETLOGS_BLOCK_RANGE) {
+            return sendRpcError(
+              res,
+              400,
+              id,
+              -32602,
+              `Invalid params: qrl_getLogs block range exceeds ${MAX_GETLOGS_BLOCK_RANGE}`
+            );
+          }
+        }
+        // Numeric from + "latest"/"pending" to is allowed: typical event-
+        // watcher pattern polls a small window up to the tip. The
+        // genesis-from check above already covers the dangerous edge.
+      }
+
+      if (Array.isArray(filter.address) && filter.address.length > MAX_GETLOGS_ADDRESSES) {
+        return sendRpcError(
+          res,
+          400,
+          id,
+          -32602,
+          `Invalid params: too many addresses (max ${MAX_GETLOGS_ADDRESSES})`
+        );
+      }
+      break;
+    }
   }
 
   next();

--- a/src/middleware/rpc-security.js
+++ b/src/middleware/rpc-security.js
@@ -243,8 +243,14 @@ export const rpcParamsValidator = (req, res, next) => {
       const filter = params[0];
 
       if (typeof filter.blockHash !== 'string') {
-        // Open-ended scans from genesis are never legitimate from this proxy.
-        if (filter.fromBlock === 'earliest' || filter.fromBlock === '0x0') {
+        const from = parseBlockTag(filter.fromBlock);
+        const to = parseBlockTag(filter.toBlock);
+
+        // Open-ended scans from genesis are never legitimate. Compare on
+        // the parsed numeric value so all hex variations of zero
+        // ("0x0", "0x00", "0x000", …) are caught — a literal-string
+        // check would be trivially bypassable.
+        if (filter.fromBlock === 'earliest' || from === 0) {
           return sendRpcError(
             res,
             400,
@@ -254,8 +260,6 @@ export const rpcParamsValidator = (req, res, next) => {
           );
         }
 
-        const from = parseBlockTag(filter.fromBlock);
-        const to = parseBlockTag(filter.toBlock);
         // Both sides numeric → enforce the range cap directly.
         if (from !== null && to !== null) {
           const range = to - from;
@@ -269,19 +273,41 @@ export const rpcParamsValidator = (req, res, next) => {
             );
           }
         }
-        // Numeric from + "latest"/"pending" to is allowed: typical event-
-        // watcher pattern polls a small window up to the tip. The
-        // genesis-from check above already covers the dangerous edge.
+        // Known gap: when `to` is "latest"/"pending" and `from` is a
+        // small-but-nonzero number, the range check is bypassed.
+        // Closing that requires querying current chain height from
+        // here (currently the middleware has no access to
+        // healthMonitor's lastHeight). Tracked for the next sprint —
+        // the genesis check above still covers the worst case.
       }
 
-      if (Array.isArray(filter.address) && filter.address.length > MAX_GETLOGS_ADDRESSES) {
-        return sendRpcError(
-          res,
-          400,
-          id,
-          -32602,
-          `Invalid params: too many addresses (max ${MAX_GETLOGS_ADDRESSES})`
-        );
+      // Address filter: reject 0x-prefixed addresses outright. Per QRL v2
+      // protocol rules addresses are Q-prefixed; a 0x-prefixed value here
+      // is either malformed or an attempt to slip Ethereum-style input
+      // through the proxy. Also cap array length so a single request
+      // can't fan out into N parallel address lookups on the node.
+      if (filter.address !== undefined && filter.address !== null) {
+        const addrs = Array.isArray(filter.address) ? filter.address : [filter.address];
+        if (addrs.length > MAX_GETLOGS_ADDRESSES) {
+          return sendRpcError(
+            res,
+            400,
+            id,
+            -32602,
+            `Invalid params: too many addresses (max ${MAX_GETLOGS_ADDRESSES})`
+          );
+        }
+        for (const a of addrs) {
+          if (typeof a === 'string' && a.startsWith('0x')) {
+            return sendRpcError(
+              res,
+              400,
+              id,
+              -32602,
+              'Invalid params: QRL addresses must be Q-prefixed'
+            );
+          }
+        }
       }
       break;
     }

--- a/src/routes/app.routes.js
+++ b/src/routes/app.routes.js
@@ -13,30 +13,48 @@ const txHistoryRateLimit = rateLimit({
   message: { message: 'Too many requests, please try again later.' },
 });
 
+const TX_HISTORY_MAX_LIMIT = 50;
+const TX_HISTORY_TIMEOUT_MS = 8000;
+
+const clampPositiveInt = (raw, fallback, max) => {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 1) return fallback;
+  const i = Math.floor(n);
+  return max ? Math.min(i, max) : i;
+};
+
 appRouter.post('/tx-history', txHistoryRateLimit, async (req, res) => {
-  const { address, page = 1, limit = 5 } = req.body;
+  const { address } = req.body;
 
   // Validate address format (Q + 40 hex chars)
   if (!address || typeof address !== 'string' || !/^Q[a-fA-F0-9]{40}$/i.test(address)) {
     return res.status(400).json({ message: 'Invalid address format' });
   }
 
+  // Clamp page/limit before proxying. Without this, a single request with
+  // limit=100000 forces zondscan to return (and us to buffer) an enormous
+  // response, and a no-timeout axios call below would block the worker for
+  // the full TCP timeout (~2 min) if zondscan stalls.
+  const page = clampPositiveInt(req.body.page, 1, null);
+  const limit = clampPositiveInt(req.body.limit, 5, TX_HISTORY_MAX_LIMIT);
+
   const formattedAddress = 'Q' + address.slice(1).toLowerCase();
-  axios
-    .get(`https://zondscan.com/api/address/${formattedAddress}/transactions`, {
-      params: {
-        page: page,
-        limit: limit,
-      },
-    })
-    .then((response) => {
-      log.debug({ address: formattedAddress }, 'Tx history fetched');
-      res.status(200).json(response.data);
-    })
-    .catch((error) => {
-      log.error({ error, address: formattedAddress }, 'Failed to get tx history');
-      res.status(500).json({ message: 'Failed to get tx history' });
-    });
+  try {
+    const response = await axios.get(
+      `https://zondscan.com/api/address/${formattedAddress}/transactions`,
+      { params: { page, limit }, timeout: TX_HISTORY_TIMEOUT_MS }
+    );
+    log.debug({ address: formattedAddress }, 'Tx history fetched');
+    res.status(200).json(response.data);
+  } catch (error) {
+    const code = error?.code;
+    if (code === 'ECONNABORTED' || code === 'ETIMEDOUT') {
+      log.warn({ address: formattedAddress, code }, 'Tx history upstream timeout');
+      return res.status(504).json({ message: 'Upstream timeout fetching tx history' });
+    }
+    log.error({ error, address: formattedAddress }, 'Failed to get tx history');
+    res.status(500).json({ message: 'Failed to get tx history' });
+  }
 });
 
 export default appRouter;

--- a/src/routes/health.routes.js
+++ b/src/routes/health.routes.js
@@ -3,8 +3,26 @@ import { healthMonitor } from '../services/rpc/healthMonitor.js';
 
 const router = Router();
 
+/**
+ * Strip the `url` field from each endpoint entry. The internal healthMonitor
+ * snapshot exposes the full upstream RPC URLs (primary/secondary nodes); we
+ * don't want anonymous internet scanners enumerating that infra.
+ * Index-by-position is preserved so the order still corresponds to the
+ * configured RPC_ENDPOINTS_<NETWORK> list.
+ */
+const redactSnapshot = (snapshot) => {
+  const out = {};
+  for (const [network, endpoints] of Object.entries(snapshot)) {
+    out[network] = endpoints.map(({ url: _url, ...rest }, index) => ({
+      index,
+      ...rest,
+    }));
+  }
+  return out;
+};
+
 router.get('/', (req, res) => {
-  const endpoints = healthMonitor.getSnapshot();
+  const endpoints = redactSnapshot(healthMonitor.getSnapshot());
   const networks = Object.keys(endpoints);
   const anyHealthy =
     networks.length === 0 || networks.some((n) => healthMonitor.hasHealthyForNetwork(n));

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,12 +1,14 @@
 import { Router } from 'express';
 import { healthRoutes } from './health.routes.js';
 import { rpcRoutes } from './rpc.routes.js';
+import { ipfsRouter } from './ipfs.routes.js';
 import appRouter from './app.routes.js';
 
 const router = Router();
 
 router.use('/health', healthRoutes);
 router.use('/api/qrl-rpc', rpcRoutes);
+router.use('/api/ipfs', ipfsRouter);
 router.use('/api', appRouter);
 
 export const routes = router;

--- a/src/routes/ipfs.routes.js
+++ b/src/routes/ipfs.routes.js
@@ -102,6 +102,14 @@ async function ipfsHandler(req, res) {
 
     const contentType = response.headers.get('content-type') || 'application/octet-stream';
 
+    // Fetch API allows response.body to be null (e.g. 204 No Content). Without
+    // an explicit check, the .getReader() call below would throw a TypeError
+    // that we'd report as "gateway unreachable" — misleading.
+    if (!response.body) {
+      log.warn({ cid, status: response.status }, 'IPFS gateway returned empty body');
+      return res.status(502).json({ error: 'gateway error' });
+    }
+
     const reader = response.body.getReader();
     const chunks = [];
     let received = 0;
@@ -124,10 +132,16 @@ async function ipfsHandler(req, res) {
         chunks.push(value);
       }
     } catch (streamErr) {
+      // An AbortError mid-stream is the FETCH_TIMEOUT_MS controller firing,
+      // not a stream-specific failure. Re-throw so the outer catch maps it
+      // to 504 like the pre-streaming code did. Anything else stays a 502.
+      if (streamErr.name === 'AbortError') throw streamErr;
       log.error({ err: streamErr.message, url }, 'IPFS proxy stream read failed');
       return res.status(502).json({ error: 'gateway stream error' });
     }
-    const buf = Buffer.concat(chunks.map((c) => Buffer.from(c)));
+    // Buffer.concat accepts Uint8Array chunks directly; the previous
+    // .map(Buffer.from) was wasted work in a hot path.
+    const buf = Buffer.concat(chunks);
 
     res.set({
       'Content-Type': contentType,

--- a/src/routes/ipfs.routes.js
+++ b/src/routes/ipfs.routes.js
@@ -136,7 +136,7 @@ async function ipfsHandler(req, res) {
       // not a stream-specific failure. Re-throw so the outer catch maps it
       // to 504 like the pre-streaming code did. Anything else stays a 502.
       if (streamErr.name === 'AbortError') throw streamErr;
-      log.error({ err: streamErr.message, url }, 'IPFS proxy stream read failed');
+      log.error({ err: streamErr, url }, 'IPFS proxy stream read failed');
       return res.status(502).json({ error: 'gateway stream error' });
     }
     // Buffer.concat accepts Uint8Array chunks directly; the previous

--- a/src/routes/ipfs.routes.js
+++ b/src/routes/ipfs.routes.js
@@ -90,17 +90,44 @@ async function ipfsHandler(req, res) {
         .json({ error: 'gateway error', status: response.status });
     }
 
-    // Reject oversize responses before buffering.
+    // Reject oversize responses up front if the gateway is honest about
+    // Content-Length. A malicious or buggy gateway can still under-declare
+    // (or omit) the header and stream arbitrarily many bytes, so we ALSO
+    // enforce the cap incrementally as we read the body — never let an
+    // attacker buffer >MAX_SIZE into our heap.
     const declaredSize = parseInt(response.headers.get('content-length') || '0', 10);
     if (declaredSize > MAX_SIZE) {
       return res.status(413).json({ error: 'too large', size: declaredSize, max: MAX_SIZE });
     }
 
     const contentType = response.headers.get('content-type') || 'application/octet-stream';
-    const buf = Buffer.from(await response.arrayBuffer());
-    if (buf.length > MAX_SIZE) {
-      return res.status(413).json({ error: 'too large', size: buf.length, max: MAX_SIZE });
+
+    const reader = response.body.getReader();
+    const chunks = [];
+    let received = 0;
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        received += value.byteLength;
+        if (received > MAX_SIZE) {
+          // Stop pulling bytes off the gateway socket before we ever
+          // commit them to our heap. cancel() may reject if the stream
+          // is already closed — swallow that.
+          try {
+            await reader.cancel();
+          } catch {
+            /* noop */
+          }
+          return res.status(413).json({ error: 'too large', size: received, max: MAX_SIZE });
+        }
+        chunks.push(value);
+      }
+    } catch (streamErr) {
+      log.error({ err: streamErr.message, url }, 'IPFS proxy stream read failed');
+      return res.status(502).json({ error: 'gateway stream error' });
     }
+    const buf = Buffer.concat(chunks.map((c) => Buffer.from(c)));
 
     res.set({
       'Content-Type': contentType,

--- a/src/routes/ipfs.routes.js
+++ b/src/routes/ipfs.routes.js
@@ -1,0 +1,130 @@
+import { Router } from 'express';
+import rateLimit from 'express-rate-limit';
+import { logger } from '../utils/logger.js';
+
+// Use Node 22's built-in fetch via globalThis so tests can stub it without
+// the ESM-default-export-immutability gymnastics that `node-fetch` requires.
+const fetchImpl = (...args) => globalThis.fetch(...args);
+
+const log = logger.child({ module: 'ipfs-routes' });
+
+/**
+ * Public IPFS gateway used to resolve user-supplied CIDs.
+ * Overridable for self-hosted gateways or staging; defaults to ipfs.io
+ * which is widely available + Cloudflare-fronted.
+ */
+const IPFS_GATEWAY = (process.env.IPFS_GATEWAY || 'https://ipfs.io/ipfs/').replace(/\/?$/, '/');
+const FETCH_TIMEOUT_MS = parseInt(process.env.IPFS_FETCH_TIMEOUT_MS || '8000', 10);
+const MAX_SIZE = parseInt(process.env.IPFS_MAX_SIZE_BYTES || String(10 * 1024 * 1024), 10); // 10 MB
+
+// CIDv0: starts with Qm + 44 base58 chars (no 0, O, I, l)
+const CIDV0_RE = /^Qm[1-9A-HJ-NP-Za-km-z]{44}$/;
+// CIDv1: starts with single multibase prefix; 'b' (base32) is by far the most
+// common. We accept the typical base32 form; other prefixes are rejected to
+// keep the surface tight.
+const CIDV1_RE = /^b[A-Za-z2-7]{58,}$/;
+// After the CID, any number of `/segment` path components are allowed. Path
+// segments may not contain `..`, `\\`, or whitespace.
+const PATH_SEGMENT_RE = /^[A-Za-z0-9._-]+$/;
+
+const ipfsRateLimit = rateLimit({
+  windowMs: 60 * 1000,
+  max: 60, // 60 requests/min/IP — well above expected normal NFT browsing
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'rate-limited' },
+});
+
+function isValidCid(cid) {
+  return CIDV0_RE.test(cid) || CIDV1_RE.test(cid);
+}
+
+function isSafePath(rest) {
+  if (!rest) return true;
+  if (rest.includes('..')) return false;
+  const segments = rest.split('/').filter(Boolean);
+  return segments.every((s) => PATH_SEGMENT_RE.test(s));
+}
+
+const ipfsRouter = Router();
+ipfsRouter.use(ipfsRateLimit);
+
+/**
+ * GET /api/ipfs/:cid             → fetches gateway/<cid>
+ * GET /api/ipfs/:cid/path/to/x   → fetches gateway/<cid>/path/to/x
+ *
+ * Used as a same-origin shim so the wallet's strict
+ * `img-src 'self' data:` CSP can still render IPFS-hosted NFT images
+ * without allowlisting every public gateway, and so JSON metadata
+ * fetches don't depend on the gateway's (often missing) CORS headers.
+ *
+ * The route does NOT accept arbitrary URLs (no `?url=` style proxying)
+ * — that would be a giant SSRF surface. Only well-formed IPFS CIDs are
+ * dereferenced through the configured `IPFS_GATEWAY`.
+ *
+ * Two route patterns share a handler because Express 4's path-to-regexp
+ * won't match `/:cid` against `/:cid/*?` — the optional star modifier still
+ * requires a `/` separator that isn't present when only the CID is supplied.
+ */
+async function ipfsHandler(req, res) {
+  const { cid } = req.params;
+  const rest = req.params[0] || '';
+
+  if (!isValidCid(cid)) {
+    return res.status(400).json({ error: 'invalid CID' });
+  }
+  if (!isSafePath(rest)) {
+    return res.status(400).json({ error: 'invalid path' });
+  }
+
+  const url = `${IPFS_GATEWAY}${cid}${rest ? '/' + rest : ''}`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetchImpl(url, { signal: controller.signal, redirect: 'follow' });
+    if (!response.ok) {
+      log.warn({ cid, status: response.status }, 'IPFS gateway returned non-2xx');
+      return res
+        .status(response.status === 404 ? 404 : 502)
+        .json({ error: 'gateway error', status: response.status });
+    }
+
+    // Reject oversize responses before buffering.
+    const declaredSize = parseInt(response.headers.get('content-length') || '0', 10);
+    if (declaredSize > MAX_SIZE) {
+      return res.status(413).json({ error: 'too large', size: declaredSize, max: MAX_SIZE });
+    }
+
+    const contentType = response.headers.get('content-type') || 'application/octet-stream';
+    const buf = Buffer.from(await response.arrayBuffer());
+    if (buf.length > MAX_SIZE) {
+      return res.status(413).json({ error: 'too large', size: buf.length, max: MAX_SIZE });
+    }
+
+    res.set({
+      'Content-Type': contentType,
+      // IPFS content is content-addressed, so caching for an hour is safe.
+      'Cache-Control': 'public, max-age=3600, immutable',
+      // Sane defaults — never let user-supplied content advertise itself
+      // as the wallet's own scripts.
+      'X-Content-Type-Options': 'nosniff',
+      'Content-Security-Policy': "default-src 'none'; img-src 'self' data: blob:; sandbox",
+    });
+    res.send(buf);
+  } catch (err) {
+    if (err.name === 'AbortError') {
+      log.warn({ cid, rest }, 'IPFS proxy timeout');
+      return res.status(504).json({ error: 'gateway timeout' });
+    }
+    log.error({ err: err.message, url }, 'IPFS proxy failed');
+    return res.status(502).json({ error: 'gateway unreachable' });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+ipfsRouter.get('/:cid', ipfsHandler);
+ipfsRouter.get('/:cid/*', ipfsHandler);
+
+export { ipfsRouter };

--- a/src/routes/rpc.routes.js
+++ b/src/routes/rpc.routes.js
@@ -61,9 +61,7 @@ router.post(
       const { network } = req.params;
       const { method, params } = req.body;
 
-      let { customRpcUrl } = req.query;
-
-      const result = await rpcService.executeRPC(network, method, params, customRpcUrl);
+      const result = await rpcService.executeRPC(network, method, params);
       res.json(result);
     } catch (error) {
       next(error);

--- a/src/services/rpc.service.js
+++ b/src/services/rpc.service.js
@@ -28,54 +28,6 @@ function isPrimaryOnlyMethod(method) {
   return PRIMARY_ONLY_PREFIXES.some((p) => method.startsWith(p));
 }
 
-/**
- * Validate a custom RPC URL to prevent SSRF attacks.
- * Blocks private IP ranges, localhost, cloud metadata endpoints, and non-HTTP protocols.
- */
-function validateCustomRpcUrl(url) {
-  let parsed;
-  try {
-    parsed = new URL(url);
-  } catch {
-    throw new Error('Invalid custom RPC URL format');
-  }
-
-  if (!['http:', 'https:'].includes(parsed.protocol)) {
-    throw new Error('Custom RPC URL must use http or https protocol');
-  }
-
-  const hostname = parsed.hostname.replace(/^\[|\]$/g, '').toLowerCase();
-
-  // Block IPv6 localhost
-  if (hostname === '::1' || hostname === '0:0:0:0:0:0:0:1') {
-    throw new Error('Custom RPC URL cannot target localhost');
-  }
-
-  // Block localhost hostnames
-  if (hostname === 'localhost' || hostname.endsWith('.localhost')) {
-    throw new Error('Custom RPC URL cannot target localhost');
-  }
-
-  // Block cloud metadata hostnames
-  if (hostname === 'metadata.google.internal') {
-    throw new Error('Custom RPC URL cannot target internal services');
-  }
-
-  // Block private/reserved IPv4 ranges
-  const ipv4Match = hostname.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
-  if (ipv4Match) {
-    const [a, b] = [Number(ipv4Match[1]), Number(ipv4Match[2])];
-    if (a === 0) throw new Error('Custom RPC URL cannot target reserved addresses');
-    if (a === 127) throw new Error('Custom RPC URL cannot target localhost');
-    if (a === 10) throw new Error('Custom RPC URL cannot target private networks');
-    if (a === 172 && b >= 16 && b <= 31)
-      throw new Error('Custom RPC URL cannot target private networks');
-    if (a === 192 && b === 168) throw new Error('Custom RPC URL cannot target private networks');
-    if (a === 169 && b === 254)
-      throw new Error('Custom RPC URL cannot target link-local addresses');
-  }
-}
-
 class RPCService {
   async makeRPCCall(endpoint, method, params) {
     const controller = new AbortController();
@@ -105,16 +57,8 @@ class RPCService {
     }
   }
 
-  async executeRPC(network, method, params, customRpcUrl = '') {
+  async executeRPC(network, method, params) {
     if (!CONFIG.RPC_ENDPOINTS[network]) {
-      throw new Error('Invalid network');
-    }
-
-    if (network === 'custom') {
-      if (customRpcUrl !== '') {
-        validateCustomRpcUrl(customRpcUrl);
-        return await this.makeRPCCall(customRpcUrl, method, params);
-      }
       throw new Error('Invalid network');
     }
 

--- a/src/services/rpc/healthMonitor.js
+++ b/src/services/rpc/healthMonitor.js
@@ -40,7 +40,6 @@ class HealthMonitor {
   init() {
     if (this.initialised) return;
     for (const [network, endpoints] of Object.entries(CONFIG.RPC_ENDPOINTS)) {
-      if (network === 'custom') continue;
       if (!Array.isArray(endpoints) || endpoints.length === 0) continue;
       this.networks.set(network, endpoints.map(makeEndpointRecord));
     }

--- a/test/routes/health.routes.test.js
+++ b/test/routes/health.routes.test.js
@@ -14,7 +14,7 @@ describe('Health Routes', () => {
     healthMonitor.__resetForTesting();
   });
 
-  it('should return status ok with per-endpoint snapshot when at least one endpoint is selectable', async () => {
+  it('should return status ok with per-endpoint snapshot (url redacted) when at least one endpoint is selectable', async () => {
     healthMonitor.__setEndpointsForTesting('testnet', ['http://example.test:8545']);
     const res = await request.execute(app).get('/health');
     expect(res).to.have.status(200);
@@ -22,9 +22,12 @@ describe('Health Routes', () => {
     expect(res.body.endpoints).to.be.an('object');
     expect(res.body.endpoints.testnet).to.be.an('array').with.lengthOf(1);
     expect(res.body.endpoints.testnet[0]).to.include({
-      url: 'http://example.test:8545',
+      index: 0,
       state: HEALTH_STATES.STATE_UNKNOWN,
     });
+    // Internal RPC URL is intentionally stripped from the public response
+    // so anonymous callers can't enumerate backend infrastructure.
+    expect(res.body.endpoints.testnet[0]).to.not.have.property('url');
   });
 
   it('should return 503 degraded when every configured endpoint is down or stalled', async () => {

--- a/test/routes/ipfs.routes.test.js
+++ b/test/routes/ipfs.routes.test.js
@@ -1,0 +1,148 @@
+import * as chai from 'chai';
+import sinon from 'sinon';
+import { default as chaiHttp, request } from 'chai-http';
+
+chai.use(chaiHttp);
+const { expect } = chai;
+
+import { app } from '../../src/app.js';
+
+function buildFetchResponse({
+  ok = true,
+  status = 200,
+  contentType = 'image/png',
+  body = Buffer.from('PNGDATA'),
+  contentLength,
+} = {}) {
+  const bufBody = body instanceof Buffer ? body : Buffer.from(body);
+  return {
+    ok,
+    status,
+    headers: {
+      get(name) {
+        const n = name.toLowerCase();
+        if (n === 'content-type') return contentType;
+        if (n === 'content-length') return String(contentLength ?? bufBody.length);
+        return null;
+      },
+    },
+    arrayBuffer: async () =>
+      bufBody.buffer.slice(bufBody.byteOffset, bufBody.byteOffset + bufBody.byteLength),
+  };
+}
+
+describe('IPFS Routes', () => {
+  let fetchStub;
+
+  beforeEach(() => {
+    fetchStub = sinon.stub(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('rejects invalid CIDs', async () => {
+    const res = await request.execute(app).get('/api/ipfs/notacid');
+    expect(res).to.have.status(400);
+    expect(res.body.error).to.equal('invalid CID');
+    expect(fetchStub.called).to.equal(false);
+  });
+
+  it('rejects path segments containing ..', async () => {
+    // `..` as its own URL segment gets collapsed by the HTTP-client URL
+    // normalizer before the request hits us, so the only way `..` reaches
+    // the route handler is inside a single segment (e.g. "foo..bar").
+    // Belt-and-suspenders: validate that the handler still rejects this.
+    const res = await request
+      .execute(app)
+      .get('/api/ipfs/QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/foo..bar');
+    expect(res).to.have.status(400);
+    expect(res.body.error).to.equal('invalid path');
+    expect(fetchStub.called).to.equal(false);
+  });
+
+  it('proxies a valid CIDv0 image through the configured gateway', async () => {
+    fetchStub.resolves(
+      buildFetchResponse({ contentType: 'image/png', body: Buffer.from('PNGDATA') }),
+    );
+
+    const cid = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
+    const res = await request.execute(app).get(`/api/ipfs/${cid}`);
+
+    expect(res).to.have.status(200);
+    expect(res).to.have.header('content-type', 'image/png');
+    expect(res).to.have.header('cache-control', /max-age=3600/);
+    expect(res.body).to.be.instanceOf(Buffer);
+    expect(res.body.toString()).to.equal('PNGDATA');
+    expect(fetchStub.calledOnce).to.equal(true);
+    expect(fetchStub.firstCall.args[0]).to.match(new RegExp(`/ipfs/${cid}$`));
+  });
+
+  it('proxies CIDv1 with a path suffix', async () => {
+    fetchStub.resolves(
+      buildFetchResponse({
+        contentType: 'application/json',
+        body: Buffer.from('{"name":"x"}'),
+      }),
+    );
+
+    const cid = 'bafybeib2gp4f5suijuyxbcfhi7lvjzvskyciye5n4ihfrn5pcwhrcq45ru';
+    const res = await request.execute(app).get(`/api/ipfs/${cid}/metadata.json`);
+
+    expect(res).to.have.status(200);
+    expect(res).to.have.header('content-type', /^application\/json/);
+    expect(fetchStub.firstCall.args[0]).to.match(
+      new RegExp(`/ipfs/${cid}/metadata\\.json$`),
+    );
+  });
+
+  it('rejects responses larger than MAX_SIZE', async () => {
+    fetchStub.resolves(
+      buildFetchResponse({ contentLength: 20 * 1024 * 1024, body: Buffer.alloc(8) }),
+    );
+
+    const cid = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
+    const res = await request.execute(app).get(`/api/ipfs/${cid}`);
+
+    expect(res).to.have.status(413);
+    expect(res.body.error).to.equal('too large');
+  });
+
+  it('returns 504 on gateway timeout', async () => {
+    const abortErr = new Error('aborted');
+    abortErr.name = 'AbortError';
+    fetchStub.rejects(abortErr);
+
+    const cid = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
+    const res = await request.execute(app).get(`/api/ipfs/${cid}`);
+
+    expect(res).to.have.status(504);
+    expect(res.body.error).to.equal('gateway timeout');
+  });
+
+  it('returns 502 on generic gateway failure', async () => {
+    fetchStub.rejects(new Error('ECONNRESET'));
+
+    const cid = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
+    const res = await request.execute(app).get(`/api/ipfs/${cid}`);
+
+    expect(res).to.have.status(502);
+    expect(res.body.error).to.equal('gateway unreachable');
+  });
+
+  it('returns 404 when the gateway returns 404', async () => {
+    fetchStub.resolves({
+      ok: false,
+      status: 404,
+      headers: { get: () => null },
+      arrayBuffer: async () => Buffer.alloc(0).buffer,
+    });
+
+    const cid = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
+    const res = await request.execute(app).get(`/api/ipfs/${cid}`);
+
+    expect(res).to.have.status(404);
+    expect(res.body.error).to.equal('gateway error');
+  });
+});

--- a/test/routes/ipfs.routes.test.js
+++ b/test/routes/ipfs.routes.test.js
@@ -7,14 +7,31 @@ const { expect } = chai;
 
 import { app } from '../../src/app.js';
 
+/**
+ * Build a stand-in for the Fetch API Response object that lets us drive
+ * the streaming read loop in ipfs.routes.js. `chunks` is an array of
+ * Uint8Array / Buffer pieces emitted in order.
+ */
 function buildFetchResponse({
   ok = true,
   status = 200,
   contentType = 'image/png',
-  body = Buffer.from('PNGDATA'),
   contentLength,
+  chunks = [Buffer.from('PNGDATA')],
 } = {}) {
-  const bufBody = body instanceof Buffer ? body : Buffer.from(body);
+  const queue = chunks.map((c) => (c instanceof Uint8Array ? c : Buffer.from(c)));
+  const totalLen = queue.reduce((n, c) => n + c.byteLength, 0);
+  let i = 0;
+  const reader = {
+    async read() {
+      if (i >= queue.length) return { done: true, value: undefined };
+      const value = queue[i++];
+      return { done: false, value };
+    },
+    async cancel() {
+      i = queue.length;
+    },
+  };
   return {
     ok,
     status,
@@ -22,12 +39,11 @@ function buildFetchResponse({
       get(name) {
         const n = name.toLowerCase();
         if (n === 'content-type') return contentType;
-        if (n === 'content-length') return String(contentLength ?? bufBody.length);
+        if (n === 'content-length') return String(contentLength ?? totalLen);
         return null;
       },
     },
-    arrayBuffer: async () =>
-      bufBody.buffer.slice(bufBody.byteOffset, bufBody.byteOffset + bufBody.byteLength),
+    body: { getReader: () => reader },
   };
 }
 
@@ -64,7 +80,7 @@ describe('IPFS Routes', () => {
 
   it('proxies a valid CIDv0 image through the configured gateway', async () => {
     fetchStub.resolves(
-      buildFetchResponse({ contentType: 'image/png', body: Buffer.from('PNGDATA') }),
+      buildFetchResponse({ contentType: 'image/png', chunks: [Buffer.from('PNGDATA')] }),
     );
 
     const cid = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
@@ -83,7 +99,7 @@ describe('IPFS Routes', () => {
     fetchStub.resolves(
       buildFetchResponse({
         contentType: 'application/json',
-        body: Buffer.from('{"name":"x"}'),
+        chunks: [Buffer.from('{"name":"x"}')],
       }),
     );
 
@@ -97,9 +113,9 @@ describe('IPFS Routes', () => {
     );
   });
 
-  it('rejects responses larger than MAX_SIZE', async () => {
+  it('rejects oversize responses up front via declared Content-Length', async () => {
     fetchStub.resolves(
-      buildFetchResponse({ contentLength: 20 * 1024 * 1024, body: Buffer.alloc(8) }),
+      buildFetchResponse({ contentLength: 20 * 1024 * 1024, chunks: [Buffer.alloc(8)] }),
     );
 
     const cid = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
@@ -107,6 +123,26 @@ describe('IPFS Routes', () => {
 
     expect(res).to.have.status(413);
     expect(res.body.error).to.equal('too large');
+  });
+
+  it('rejects oversize responses mid-stream even when Content-Length lies', async () => {
+    // Gateway lies in the header (says 10 bytes) but actually streams 12 MB
+    // in 1 MB chunks. The handler must trip the incremental cap and 413
+    // instead of buffering the whole thing into memory.
+    const oneMb = Buffer.alloc(1024 * 1024);
+    fetchStub.resolves(
+      buildFetchResponse({
+        contentLength: 10,
+        chunks: Array(12).fill(oneMb),
+      }),
+    );
+
+    const cid = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
+    const res = await request.execute(app).get(`/api/ipfs/${cid}`);
+
+    expect(res).to.have.status(413);
+    expect(res.body.error).to.equal('too large');
+    expect(res.body.size).to.be.greaterThan(10 * 1024 * 1024);
   });
 
   it('returns 504 on gateway timeout', async () => {
@@ -131,12 +167,42 @@ describe('IPFS Routes', () => {
     expect(res.body.error).to.equal('gateway unreachable');
   });
 
+  it('returns 502 when the body stream throws mid-read', async () => {
+    fetchStub.resolves({
+      ok: true,
+      status: 200,
+      headers: {
+        get(name) {
+          const n = name.toLowerCase();
+          if (n === 'content-type') return 'image/png';
+          if (n === 'content-length') return '100';
+          return null;
+        },
+      },
+      body: {
+        getReader() {
+          return {
+            async read() {
+              throw new Error('socket hang up');
+            },
+            async cancel() {},
+          };
+        },
+      },
+    });
+
+    const cid = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
+    const res = await request.execute(app).get(`/api/ipfs/${cid}`);
+
+    expect(res).to.have.status(502);
+    expect(res.body.error).to.equal('gateway stream error');
+  });
+
   it('returns 404 when the gateway returns 404', async () => {
     fetchStub.resolves({
       ok: false,
       status: 404,
       headers: { get: () => null },
-      arrayBuffer: async () => Buffer.alloc(0).buffer,
     });
 
     const cid = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';

--- a/test/routes/ipfs.routes.test.js
+++ b/test/routes/ipfs.routes.test.js
@@ -167,6 +167,66 @@ describe('IPFS Routes', () => {
     expect(res.body.error).to.equal('gateway unreachable');
   });
 
+  it('returns 502 when the gateway response has a null body', async () => {
+    // Fetch API allows null body (e.g. 204 No Content). Handler must surface
+    // this as a clean gateway error rather than letting .getReader() blow up.
+    fetchStub.resolves({
+      ok: true,
+      status: 200,
+      headers: {
+        get(name) {
+          const n = name.toLowerCase();
+          if (n === 'content-type') return 'image/png';
+          if (n === 'content-length') return '0';
+          return null;
+        },
+      },
+      body: null,
+    });
+
+    const cid = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
+    const res = await request.execute(app).get(`/api/ipfs/${cid}`);
+
+    expect(res).to.have.status(502);
+    expect(res.body.error).to.equal('gateway error');
+  });
+
+  it('returns 504 when an AbortError fires during stream read', async () => {
+    // FETCH_TIMEOUT_MS controller can fire AFTER the response headers are
+    // received — the inner stream-read catch must re-throw AbortError so
+    // the outer catch maps it to 504, not the generic 502 stream error.
+    const abortErr = new Error('aborted mid-stream');
+    abortErr.name = 'AbortError';
+    fetchStub.resolves({
+      ok: true,
+      status: 200,
+      headers: {
+        get(name) {
+          const n = name.toLowerCase();
+          if (n === 'content-type') return 'image/png';
+          if (n === 'content-length') return '1000';
+          return null;
+        },
+      },
+      body: {
+        getReader() {
+          return {
+            async read() {
+              throw abortErr;
+            },
+            async cancel() {},
+          };
+        },
+      },
+    });
+
+    const cid = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
+    const res = await request.execute(app).get(`/api/ipfs/${cid}`);
+
+    expect(res).to.have.status(504);
+    expect(res.body.error).to.equal('gateway timeout');
+  });
+
   it('returns 502 when the body stream throws mid-read', async () => {
     fetchStub.resolves({
       ok: true,

--- a/test/services/rpc.service.test.js
+++ b/test/services/rpc.service.test.js
@@ -42,7 +42,7 @@ describe('RPC Service', () => {
     expect(CONFIG.RPC_ENDPOINTS).to.have.property('dev');
     expect(CONFIG.RPC_ENDPOINTS).to.have.property('testnet');
     expect(CONFIG.RPC_ENDPOINTS).to.have.property('mainnet');
-    expect(CONFIG.RPC_ENDPOINTS).to.have.property('custom');
+    expect(CONFIG.RPC_ENDPOINTS).to.not.have.property('custom');
   });
 
   describe('caching behavior', () => {


### PR DESCRIPTION
## Why

Prod backend is 12 commits behind `dev`. The wallet frontend already shipped the NFT discovery UI in v2.0.0 (frontend PR #147), but it hits `/api/ipfs/:cid` for metadata + images, which currently 404s in prod because the backend route lives only on `dev`. Cutting this release lights up NFT support end-to-end.

Reported externally as "issues with fetching metadata in the wallet" on both `qrlwallet.com` and `dev.qrlwallet.com`. Prod nginx has been patched separately to route `/api/ipfs/` → `localhost:3000`; this PR provides the backend handler it expects.

## What's in this release

**IPFS proxy (PRs #41 / #42 / #43)**
- `src/routes/ipfs.routes.js` (+171): same-origin `/api/ipfs/:cid[/path]` proxy, CIDv0/CIDv1 validation, path traversal guard, 60 req/min/IP rate limit, 8s gateway timeout (504), 10 MB cap enforced **while streaming** (not after buffering), `Content-Security-Policy: default-src 'none'; sandbox` on the response.
- Test suite at `test/routes/ipfs.routes.test.js` (+274).
- Default gateway is `https://ipfs.io/ipfs/`, overridable via `IPFS_GATEWAY` env.

**Scalability sprint-1 (PR #40)**
- Bounded `qrl_getLogs` block range to prevent unbounded RPC scans.
- Clamped tx-history pagination.
- Redacted RPC URLs in `/health` snapshots (Gemini follow-up).

**Custom RPC removal (PR #45)**
- Drops the `custom` network path and its SSRF perimeter validator (`validateCustomRpcUrl`). The frontend UI for arbitrary RPC endpoints was already removed in the matching frontend change.

## Risk

- Fast-forward only (`origin/dev..origin/main` is empty). No drift on main.
- IPFS route is additive. New rate limit (60/min/IP) sits in front of it; well above expected NFT browse volume.
- Custom-RPC removal closes off a feature surface, mainnet/testnet paths are unaffected.
- No env-var changes required for the baseline rollout (defaults work). Optional: set `IPFS_GATEWAY` in `~/myqrlwallet-backend/.env` for a non-default gateway.

## Test plan

- [ ] Auto-deploy webhook fires on push to main → `pm2 restart myqrlwallet-backend`.
- [ ] `curl -s -o /dev/null -w "%{http_code}\n" https://qrlwallet.com/api/ipfs/QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/readme` returns 200 (was returning SPA HTML or 404).
- [ ] `curl -s https://qrlwallet.com/api/qrl-rpc/testnet -d '{"jsonrpc":"2.0","method":"qrl_blockNumber","params":[],"id":1}' -H 'Content-Type: application/json'` still returns a block number.
- [ ] `pm2 logs myqrlwallet-backend` shows no startup errors.
- [ ] Open `qrlwallet.com`, add an NFT with a real (pinned) IPFS metadata URI, image renders.