### PR TITLE
feat(relay): participant roster + terminated tombstone (connect resilience)

### DIFF
--- a/src/relay/channelManager.js
+++ b/src/relay/channelManager.js
@@ -15,6 +15,13 @@ const CLEANUP_INTERVAL_MS = 60 * 1000; // Run cleanup every minute
 // cannot grow without limit; a dApp re-joining after this simply finds no
 // wallet present and falls back to QR via the normal liveness path.
 const TOMBSTONE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+// Hard cap on retained tombstones. Terminated channels are excluded from the
+// active-channel admission count, so without this an attacker could create +
+// immediately close channels in a loop and accumulate unbounded tombstones
+// (each held for TOMBSTONE_TTL_MS) until the relay exhausts memory. When the
+// cap is exceeded the oldest tombstone is evicted; a dApp re-joining an evicted
+// channel simply finds no wallet and falls back to QR via the liveness path.
+const MAX_TOMBSTONES = 20000;
 // ML-KEM-768 public key is 1184 bytes → ~1580 chars base64. Cap at 2048
 // raw bytes (~2730 chars) so a future KEM doesn't require a protocol
 // change on the relay, but tightly enough that a malicious client can't
@@ -25,6 +32,8 @@ class ChannelManager {
   constructor(options = {}) {
     /** @type {Map<string, Channel>} */
     this.channels = new Map();
+    /** @type {string[]} FIFO of terminated channelIds, for tombstone eviction. */
+    this.terminatedOrder = [];
     this.isSocketActive = options.isSocketActive || (() => false);
     this.cleanupTimer = setInterval(() => this.cleanup(), CLEANUP_INTERVAL_MS);
   }
@@ -186,6 +195,24 @@ class ChannelManager {
     channel.terminated = true;
     channel.terminatedAt = Date.now();
     channel.lastActivity = Date.now();
+    // A terminated channel routes nothing, so drop its heavy state now rather
+    // than holding it for TOMBSTONE_TTL_MS. The tombstone keeps only the
+    // terminated flag + timestamps.
+    channel.messageBuffer = [];
+    channel.participants.clear();
+    channel.seqNumbers.clear();
+    channel.publicKey = null;
+    // Bound the number of retained tombstones (see MAX_TOMBSTONES). Evict the
+    // oldest when over budget; entries already removed by the TTL cleanup are
+    // skipped.
+    this.terminatedOrder.push(channelId);
+    while (this.terminatedOrder.length > MAX_TOMBSTONES) {
+      const oldest = this.terminatedOrder.shift();
+      const stale = this.channels.get(oldest);
+      if (stale && stale.terminated) {
+        this.channels.delete(oldest);
+      }
+    }
   }
 
   /**
@@ -337,6 +364,12 @@ class ChannelManager {
       if (channel.participants.size === 0 && now - channel.lastActivity > CHANNEL_TTL_MS) {
         this.channels.delete(channelId);
       }
+    }
+
+    // Keep the tombstone FIFO in sync with the TTL deletions above so it does
+    // not retain references to channels that no longer exist.
+    if (this.terminatedOrder.length > 0) {
+      this.terminatedOrder = this.terminatedOrder.filter((id) => this.channels.has(id));
     }
   }
 

--- a/src/relay/channelManager.js
+++ b/src/relay/channelManager.js
@@ -8,6 +8,13 @@ const MAX_PARTICIPANTS = 2;
 const MAX_BUFFERED_MESSAGES = 50;
 const BUFFER_TTL_MS = 5 * 60 * 1000; // 5 minutes
 const CLEANUP_INTERVAL_MS = 60 * 1000; // Run cleanup every minute
+// How long an explicit "terminated" tombstone is retained after the channel
+// empties. A dApp that re-joins within this window learns the session was
+// torn down on purpose (so it drops its stored session immediately) instead
+// of sitting on a liveness timeout. Kept generous but bounded so tombstones
+// cannot grow without limit; a dApp re-joining after this simply finds no
+// wallet present and falls back to QR via the normal liveness path.
+const TOMBSTONE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 // ML-KEM-768 public key is 1184 bytes → ~1580 chars base64. Cap at 2048
 // raw bytes (~2730 chars) so a future KEM doesn't require a protocol
 // change on the relay, but tightly enough that a malicious client can't
@@ -55,6 +62,10 @@ class ChannelManager {
         seqNumbers: new Map(),
         /** @type {string|null} dApp's base64-encoded KEM public key. */
         publicKey: null,
+        /** @type {boolean} Set when a participant explicitly closed the channel. */
+        terminated: false,
+        /** @type {number} When the channel was terminated (for tombstone TTL). */
+        terminatedAt: 0,
       };
       this.channels.set(channelId, channel);
     }
@@ -137,11 +148,53 @@ class ChannelManager {
     }
     channel.messageBuffer = newBuffer;
 
+    // Roster of the OTHER participants' client types, so a (re)joining peer
+    // can immediately tell whether its counterparty is present rather than
+    // waiting on a future participants_changed event that may never come
+    // (e.g. the wallet left while the dApp tab was closed). Computed after
+    // adding self, then filtered to exclude self.
+    const counterpartyTypes = [];
+    for (const [sid, p] of channel.participants) {
+      if (sid !== socketId) counterpartyTypes.push(p.clientType);
+    }
+
     return {
       success: true,
       bufferedMessages: buffered.map((msg) => msg.data),
       channelPublicKey: channel.publicKey,
+      participants: counterpartyTypes,
+      terminated: channel.terminated === true,
     };
+  }
+
+  /**
+   * Explicitly terminate a channel (wallet- or dApp-initiated disconnect /
+   * "forget"). Marks a durable tombstone so a peer re-joining later learns
+   * the session was torn down on purpose and drops its stored session,
+   * instead of sitting on a liveness timeout or re-pairing a dead channel.
+   * The tombstone is retained for TOMBSTONE_TTL_MS and is excluded from the
+   * active-channel admission count so it cannot block new channels.
+   * @param {string} channelId
+   */
+  close(channelId) {
+    let channel = this.channels.get(channelId);
+    if (!channel) {
+      // Peer already gone and channel GC'd: create a minimal tombstone so a
+      // later re-join still learns the session is dead.
+      channel = {
+        participants: new Map(),
+        lastActivity: Date.now(),
+        messageBuffer: [],
+        seqNumbers: new Map(),
+        publicKey: null,
+        terminated: false,
+        terminatedAt: 0,
+      };
+      this.channels.set(channelId, channel);
+    }
+    channel.terminated = true;
+    channel.terminatedAt = Date.now();
+    channel.lastActivity = Date.now();
   }
 
   /**
@@ -270,6 +323,15 @@ class ChannelManager {
         (msg) => now - msg.timestamp < BUFFER_TTL_MS
       );
 
+      // Terminated tombstones live on their own (longer) TTL so a dApp that
+      // re-joins within a day still learns the session was closed on purpose.
+      if (channel.terminated) {
+        if (channel.participants.size === 0 && now - channel.terminatedAt > TOMBSTONE_TTL_MS) {
+          this.channels.delete(channelId);
+        }
+        continue;
+      }
+
       // Remove channels inactive beyond TTL with no participants
       if (channel.participants.size === 0 && now - channel.lastActivity > CHANNEL_TTL_MS) {
         this.channels.delete(channelId);
@@ -297,11 +359,17 @@ class ChannelManager {
   }
 
   /**
-   * Get current number of tracked channels in O(1).
-   * Useful for admission control before creating new channels.
+   * Get the number of live (non-terminated) channels, used for admission
+   * control before creating new channels. Terminated tombstones are excluded
+   * so a burst of closes cannot exhaust the active-channel budget. Bounded by
+   * the channel cap, so the linear scan is cheap.
    */
   getActiveChannelCount() {
-    return this.channels.size;
+    let count = 0;
+    for (const channel of this.channels.values()) {
+      if (!channel.terminated) count += 1;
+    }
+    return count;
   }
 
   /**

--- a/src/relay/channelManager.js
+++ b/src/relay/channelManager.js
@@ -62,6 +62,21 @@ class ChannelManager {
   join(channelId, socketId, clientType, publicKeyBase64) {
     let channel = this.channels.get(channelId);
 
+    // Re-join to an explicitly closed channel: report the tombstone so the
+    // (re)joining peer drops its stored session, but do NOT resurrect it or
+    // add a participant. Parking a socket in a dead channel would both skip
+    // the active-channel admission cap (getChannelInfo stays truthy) and let
+    // an attacker loop join->close to flood the tombstone FIFO.
+    if (channel && channel.terminated) {
+      return {
+        success: true,
+        bufferedMessages: [],
+        channelPublicKey: null,
+        participants: [],
+        terminated: true,
+      };
+    }
+
     if (!channel) {
       channel = {
         participants: new Map(),
@@ -192,6 +207,11 @@ class ChannelManager {
     // peer sees no participants anyway), and creating one would let an
     // attacker fill memory with tombstones that bypass the channel cap.
     if (!channel) return;
+    // Idempotent: a channel can only be tombstoned once. Without this a
+    // repeated close() (or a re-join->close loop on the same id) would push
+    // duplicate entries into terminatedOrder and the FIFO eviction would then
+    // flush out legitimate tombstones.
+    if (channel.terminated) return;
     channel.terminated = true;
     channel.terminatedAt = Date.now();
     channel.lastActivity = Date.now();

--- a/src/relay/channelManager.js
+++ b/src/relay/channelManager.js
@@ -224,6 +224,13 @@ class ChannelManager {
       return { buffered: false, error: 'Channel not found' };
     }
 
+    // A terminated channel (explicit close / tombstone) is dead. Refuse to
+    // route so a peer that never received or ignored the 'close' event cannot
+    // keep using it until the 24h tombstone TTL expires.
+    if (channel.terminated) {
+      return { buffered: false, error: 'Channel terminated' };
+    }
+
     channel.lastActivity = Date.now();
 
     const sender = channel.participants.get(senderSocketId);

--- a/src/relay/channelManager.js
+++ b/src/relay/channelManager.js
@@ -177,21 +177,12 @@ class ChannelManager {
    * @param {string} channelId
    */
   close(channelId) {
-    let channel = this.channels.get(channelId);
-    if (!channel) {
-      // Peer already gone and channel GC'd: create a minimal tombstone so a
-      // later re-join still learns the session is dead.
-      channel = {
-        participants: new Map(),
-        lastActivity: Date.now(),
-        messageBuffer: [],
-        seqNumbers: new Map(),
-        publicKey: null,
-        terminated: false,
-        terminatedAt: 0,
-      };
-      this.channels.set(channelId, channel);
-    }
+    const channel = this.channels.get(channelId);
+    // Only mark an existing channel. Never fabricate a tombstone for an
+    // unknown channelId: a non-existent channel is already dead (a re-joining
+    // peer sees no participants anyway), and creating one would let an
+    // attacker fill memory with tombstones that bypass the channel cap.
+    if (!channel) return;
     channel.terminated = true;
     channel.terminatedAt = Date.now();
     channel.lastActivity = Date.now();
@@ -325,8 +316,11 @@ class ChannelManager {
 
       // Terminated tombstones live on their own (longer) TTL so a dApp that
       // re-joins within a day still learns the session was closed on purpose.
+      // Delete strictly on age regardless of participant count: a lingering
+      // participant (or a socket leak) must not pin a tombstone in memory
+      // forever.
       if (channel.terminated) {
-        if (channel.participants.size === 0 && now - channel.terminatedAt > TOMBSTONE_TTL_MS) {
+        if (now - channel.terminatedAt > TOMBSTONE_TTL_MS) {
           this.channels.delete(channelId);
         }
         continue;

--- a/src/relay/relayServer.js
+++ b/src/relay/relayServer.js
@@ -272,6 +272,11 @@ export function createRelayServer(httpServer) {
         success: true,
         bufferedMessages: result.bufferedMessages || [],
         channelPublicKey: result.channelPublicKey || null,
+        // Counterparty roster so a (re)joining peer can detect an absent
+        // wallet immediately; `terminated` flags a channel that was closed
+        // on purpose so the peer drops its stored session instead of waiting.
+        participants: result.participants || [],
+        terminated: result.terminated || false,
       });
     });
 
@@ -326,6 +331,35 @@ export function createRelayServer(httpServer) {
         // Notify other participant
         socket.to(channelId).emit('participants_changed', {
           event: 'leave',
+          clientType: participant?.clientType || null,
+        });
+
+        if (currentChannelId === channelId) {
+          currentChannelId = null;
+        }
+      }
+
+      callback?.({ success: true });
+    });
+
+    /**
+     * close_channel - Explicitly terminate a channel (an intentional
+     * disconnect / "forget", as opposed to a transient socket drop on
+     * backgrounding). Marks a durable tombstone so the counterparty learns
+     * the session is dead even if it is absent now and re-joins later.
+     */
+    socket.on('close_channel', (payload, callback) => {
+      const channelId = payload?.channelId || currentChannelId;
+
+      if (isValidChannelId(channelId)) {
+        channelManager.close(channelId);
+        socket.leave(channelId);
+        const participant = channelManager.leave(socket.id, channelId);
+
+        // Tell a currently-connected counterparty this was an explicit close,
+        // distinct from a transient 'disconnect'.
+        socket.to(channelId).emit('participants_changed', {
+          event: 'close',
           clientType: participant?.clientType || null,
         });
 

--- a/src/relay/relayServer.js
+++ b/src/relay/relayServer.js
@@ -352,19 +352,28 @@ export function createRelayServer(httpServer) {
       const channelId = payload?.channelId || currentChannelId;
 
       if (isValidChannelId(channelId)) {
-        channelManager.close(channelId);
+        // Authorize: only an actual participant may terminate the channel.
+        // leave() returns the participant record (and null if this socket is
+        // not in the channel), so it doubles as the membership check. This
+        // blocks an attacker from closing arbitrary channels by guessing a
+        // channelId, and from creating tombstones for channels they were
+        // never part of (the close() below only marks an existing channel).
         socket.leave(channelId);
         const participant = channelManager.leave(socket.id, channelId);
 
-        // Tell a currently-connected counterparty this was an explicit close,
-        // distinct from a transient 'disconnect'.
-        socket.to(channelId).emit('participants_changed', {
-          event: 'close',
-          clientType: participant?.clientType || null,
-        });
+        if (participant) {
+          channelManager.close(channelId);
 
-        if (currentChannelId === channelId) {
-          currentChannelId = null;
+          // Tell a currently-connected counterparty this was an explicit
+          // close, distinct from a transient 'disconnect'.
+          socket.to(channelId).emit('participants_changed', {
+            event: 'close',
+            clientType: participant.clientType,
+          });
+
+          if (currentChannelId === channelId) {
+            currentChannelId = null;
+          }
         }
       }
 

--- a/test/relay/relay.test.js
+++ b/test/relay/relay.test.js
@@ -768,5 +768,25 @@ describe('Relay Server', function () {
         clearInterval(cm.cleanupTimer);
       }
     });
+
+    it('close() is idempotent and a tombstone re-join parks no participant', () => {
+      const cm = new ChannelManager();
+      try {
+        cm.join('dup-ch', 'sock-a', 'dapp');
+        cm.close('dup-ch');
+        expect(cm.terminatedOrder.length).to.equal(1);
+        // Idempotent: a second close (or a join->close loop on the same id)
+        // must not push a duplicate FIFO entry that would flush real tombstones.
+        cm.close('dup-ch');
+        expect(cm.terminatedOrder.length).to.equal(1);
+        // A re-join to the tombstone reports terminated and adds no participant.
+        const rejoin = cm.join('dup-ch', 'sock-b', 'dapp');
+        expect(rejoin.success).to.be.true;
+        expect(rejoin.terminated).to.be.true;
+        expect(cm.channels.get('dup-ch').participants.size).to.equal(0);
+      } finally {
+        clearInterval(cm.cleanupTimer);
+      }
+    });
   });
 });

--- a/test/relay/relay.test.js
+++ b/test/relay/relay.test.js
@@ -708,5 +708,23 @@ describe('Relay Server', function () {
       await disconnect(dapp);
       await disconnect(wallet);
     });
+
+    it('refuses to route messages on a terminated channel', async () => {
+      const wallet = await connect(relay.port);
+      const dapp = await connect(relay.port);
+      await joinChannel(wallet, 'closed-route', 'wallet');
+      await joinChannel(dapp, 'closed-route', 'dapp');
+      // The wallet explicitly closes (tombstones) the channel.
+      await new Promise((resolve) => {
+        wallet.emit('close_channel', { channelId: 'closed-route' }, () => resolve());
+      });
+      // A peer that never received or ignored the 'close' event must not be
+      // able to keep routing through the dead channel.
+      const ack = await sendMessage(dapp, 'closed-route', 'after-close', 'dapp');
+      expect(ack.success).to.be.false;
+      expect(ack.error).to.equal('Channel terminated');
+      await disconnect(dapp);
+      await disconnect(wallet);
+    });
   });
 });

--- a/test/relay/relay.test.js
+++ b/test/relay/relay.test.js
@@ -10,6 +10,7 @@ import { createServer } from 'http';
 import { io as ioc } from 'socket.io-client';
 import { CONFIG } from '../../src/config/index.js';
 import { createRelayServer } from '../../src/relay/relayServer.js';
+import { ChannelManager } from '../../src/relay/channelManager.js';
 
 const { expect } = chai;
 
@@ -725,6 +726,47 @@ describe('Relay Server', function () {
       expect(ack.error).to.equal('Channel terminated');
       await disconnect(dapp);
       await disconnect(wallet);
+    });
+  });
+
+  // ── ChannelManager unit: tombstone memory hygiene ────────────────────
+
+  describe('ChannelManager tombstones', () => {
+    it('close() clears heavy channel state but keeps the tombstone flag', () => {
+      const cm = new ChannelManager();
+      try {
+        // dApp joins (binding a PK) with no counterparty yet, so a routed
+        // message has nowhere to go and is buffered.
+        cm.join('unit-close', 'sock-d', 'dapp', 'YQ==');
+        const routed = cm.routeMessage('unit-close', 'sock-d', {
+          id: 'unit-close',
+          message: 'x',
+          seq: 0,
+        });
+        expect(routed.buffered).to.be.true;
+        const before = cm.channels.get('unit-close');
+        expect(before.messageBuffer.length).to.equal(1);
+        expect(before.participants.size).to.equal(1);
+        expect(before.seqNumbers.size).to.equal(1);
+        expect(before.publicKey).to.equal('YQ==');
+
+        cm.close('unit-close');
+
+        const after = cm.channels.get('unit-close');
+        expect(after.terminated).to.be.true;
+        expect(after.participants.size).to.equal(0);
+        expect(after.seqNumbers.size).to.equal(0);
+        expect(after.messageBuffer.length).to.equal(0);
+        expect(after.publicKey).to.equal(null);
+        // Tombstone is excluded from the active-channel admission count.
+        expect(cm.getActiveChannelCount()).to.equal(0);
+        // ... and routing through it is refused.
+        expect(
+          cm.routeMessage('unit-close', 'sock-d', { id: 'unit-close', message: 'y', seq: 1 }).error
+        ).to.equal('Channel terminated');
+      } finally {
+        clearInterval(cm.cleanupTimer);
+      }
     });
   });
 });

--- a/test/relay/relay.test.js
+++ b/test/relay/relay.test.js
@@ -649,4 +649,64 @@ describe('Relay Server', function () {
       await disconnect(s);
     });
   });
+
+  // ── Participant roster + terminated tombstone ────────────────────────
+
+  describe('roster and tombstone', () => {
+    let relay;
+
+    before(async () => { relay = await startRelay(); });
+    after(() => relay.cleanup());
+
+    it('join ack reports an empty roster when the peer joins alone', async () => {
+      const dapp = await connect(relay.port);
+      const resp = await joinChannel(dapp, 'roster-alone', 'dapp');
+      expect(resp.success).to.be.true;
+      expect(resp.participants).to.deep.equal([]);
+      expect(resp.terminated).to.be.false;
+      await disconnect(dapp);
+    });
+
+    it('join ack reports the counterparty client type when present', async () => {
+      const dapp = await connect(relay.port);
+      const wallet = await connect(relay.port);
+      await joinChannel(dapp, 'roster-pair', 'dapp');
+      const walletAck = await joinChannel(wallet, 'roster-pair', 'wallet');
+      expect(walletAck.success).to.be.true;
+      // The wallet joined second, so it sees the dApp already in the channel.
+      expect(walletAck.participants).to.deep.equal(['dapp']);
+      await disconnect(dapp);
+      await disconnect(wallet);
+    });
+
+    it('close_channel marks a tombstone surfaced on a later re-join', async () => {
+      const dapp = await connect(relay.port);
+      await joinChannel(dapp, 'tombstone-ch', 'dapp');
+      await new Promise((resolve) => {
+        dapp.emit('close_channel', { channelId: 'tombstone-ch' }, () => resolve());
+      });
+      await disconnect(dapp);
+
+      // A fresh dApp socket re-joining the same channel learns it was closed.
+      const dapp2 = await connect(relay.port);
+      const resp = await joinChannel(dapp2, 'tombstone-ch', 'dapp');
+      expect(resp.success).to.be.true;
+      expect(resp.terminated).to.be.true;
+      await disconnect(dapp2);
+    });
+
+    it('notifies a connected counterparty of an explicit close', async () => {
+      const dapp = await connect(relay.port);
+      const wallet = await connect(relay.port);
+      await joinChannel(dapp, 'close-notify', 'dapp');
+      await joinChannel(wallet, 'close-notify', 'wallet');
+      const evt = waitForEvent(dapp, 'participants_changed');
+      wallet.emit('close_channel', { channelId: 'close-notify' });
+      const data = await evt;
+      expect(data.event).to.equal('close');
+      expect(data.clientType).to.equal('wallet');
+      await disconnect(dapp);
+      await disconnect(wallet);
+    });
+  });
 });


### PR DESCRIPTION
Relay foundation for the dApp-connect stale-session + mobile-backgrounding fixes (see the connection-resilience review). Additive and backward-compatible: existing clients ignore the new ack fields; the new event is opt-in.

## Changes
- `join_channel` ack returns `participants` (the counterparty client types already in the channel) so a re-joining dApp can detect an absent wallet immediately instead of waiting on a `participants_changed` event that never comes when the wallet left while the dApp was offline.
- New `close_channel` event marks a durable `terminated` tombstone (24h TTL, excluded from the active-channel admission count) surfaced as `terminated:true` on the peer's next join ack, so an explicit wallet/app-side disconnect reaches a dApp that was absent at close time. A connected counterparty also gets `participants_changed event:'close'` (distinct from a transient `disconnect`).

## Gates
`format:check`, `lint`, `test` -> 75 passing (+4 new relay cases: empty roster, counterparty roster, tombstone-on-rejoin, close notification).

Independent PR (base `dev`). The SDK/wallet/app PRs consume these fields but degrade gracefully against an old relay.