### PR TITLE
feat(relay): env-tunable ping interval/timeout

### DIFF
--- a/src/relay/relayServer.js
+++ b/src/relay/relayServer.js
@@ -59,8 +59,14 @@ export function createRelayServer(httpServer) {
     },
     path: '/relay',
     transports: ['websocket', 'polling'],
-    pingInterval: 25000,
-    pingTimeout: 20000,
+    // Tunable keepalive cadence. Some client network paths (observed:
+    // mobile WebView traffic, likely via iCloud Private Relay or an
+    // idle-reaping middlebox) kill websockets after ~5s without traffic;
+    // device diagnostics showed connections dying at aliveMs ~5.2-5.4s
+    // like clockwork. A pingInterval below the reap threshold keeps the
+    // socket alive at the cost of a 2-byte frame per interval.
+    pingInterval: parseInt(process.env.RELAY_PING_INTERVAL_MS || '25000', 10),
+    pingTimeout: parseInt(process.env.RELAY_PING_TIMEOUT_MS || '20000', 10),
     maxHttpBufferSize: MAX_MESSAGE_BYTES,
   });
 


### PR DESCRIPTION
Device diagnostics (frontend #194) showed websockets from the phone dying at aliveMs 5.2-5.4s consistently (visible, online, detail=websocket error) while desktop connections idle for minutes unharmed: an idle-reaper on the phone's network path (iCloud Private Relay suspected). Makes the relay keepalive cadence env-tunable; dev gets RELAY_PING_INTERVAL_MS=4000 to hold traffic under the reap threshold as a live experiment. Defaults unchanged. Gates: format:check, lint, 79 tests passing.