### PR TITLE
fix(relay): centralize ping config with NaN/non-positive guards

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -23,6 +23,16 @@ function parseEndpointList(networkKey, fallback = []) {
   return fallback;
 }
 
+/**
+ * Parse a positive-integer env var, falling back when unset, non-numeric,
+ * zero, or negative. Keepalive intervals fed to Socket.IO must never be
+ * NaN or <= 0 (unexpected drops / crashes).
+ */
+function parsePositiveInt(value, fallback) {
+  const n = parseInt(value ?? '', 10);
+  return Number.isInteger(n) && n > 0 ? n : fallback;
+}
+
 export const CONFIG = {
   PORT: process.env.PORT || 3000,
   NODE_ENV: process.env.NODE_ENV || 'development',
@@ -32,6 +42,8 @@ export const CONFIG = {
   RELAY_MAX_ACTIVE_SOCKETS: parseInt(process.env.RELAY_MAX_ACTIVE_SOCKETS || '5000', 10),
   RELAY_MAX_SOCKETS_PER_IP: parseInt(process.env.RELAY_MAX_SOCKETS_PER_IP || '25', 10),
   RELAY_MAX_ACTIVE_CHANNELS: parseInt(process.env.RELAY_MAX_ACTIVE_CHANNELS || '20000', 10),
+  RELAY_PING_INTERVAL_MS: parsePositiveInt(process.env.RELAY_PING_INTERVAL_MS, 25000),
+  RELAY_PING_TIMEOUT_MS: parsePositiveInt(process.env.RELAY_PING_TIMEOUT_MS, 20000),
 
   ALLOWED_ORIGINS: (process.env.ALLOWED_ORIGINS || '')
     .split(',')

--- a/src/relay/relayServer.js
+++ b/src/relay/relayServer.js
@@ -65,8 +65,8 @@ export function createRelayServer(httpServer) {
     // device diagnostics showed connections dying at aliveMs ~5.2-5.4s
     // like clockwork. A pingInterval below the reap threshold keeps the
     // socket alive at the cost of a 2-byte frame per interval.
-    pingInterval: parseInt(process.env.RELAY_PING_INTERVAL_MS || '25000', 10),
-    pingTimeout: parseInt(process.env.RELAY_PING_TIMEOUT_MS || '20000', 10),
+    pingInterval: CONFIG.RELAY_PING_INTERVAL_MS,
+    pingTimeout: CONFIG.RELAY_PING_TIMEOUT_MS,
     maxHttpBufferSize: MAX_MESSAGE_BYTES,
   });
 


### PR DESCRIPTION
Review follow-up from #53/#54: malformed RELAY_PING_* env values fed NaN into Socket.IO keepalive options. Parsing centralized in config with positive-integer validation and default fallback. Gates: format:check, lint, 79/79 tests.