### PR TITLE
release: extension-scheme CORS allowance

### DIFF
--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -2,9 +2,20 @@ import cors from 'cors';
 import { CONFIG } from '../config/index.js';
 import { HttpError } from '../utils/guards.js';
 
+// Browser-extension origins are allowed as a SCHEME rather than per-ID:
+// unpacked extension IDs differ per machine, and a request WITHOUT an
+// Origin header (curl, native clients) already passes below, so an
+// extension page gains no capability a headerless client does not have.
+// Web pages remain gated by the ALLOWED_ORIGINS allowlist.
+const EXTENSION_SCHEMES = ['chrome-extension://', 'moz-extension://', 'safari-web-extension://'];
+
 export const corsMiddleware = cors({
   origin: (origin, callback) => {
-    if (!origin || CONFIG.ALLOWED_ORIGINS.includes(origin)) {
+    if (
+      !origin ||
+      CONFIG.ALLOWED_ORIGINS.includes(origin) ||
+      EXTENSION_SCHEMES.some((scheme) => origin.startsWith(scheme))
+    ) {
       callback(null, true);
     } else {
       // 403, not a generic 500: a disallowed Origin is a client-side policy

--- a/test/middleware.cors.test.js
+++ b/test/middleware.cors.test.js
@@ -1,0 +1,56 @@
+/**
+ * corsMiddleware origin policy: allowlisted web origins and browser-extension
+ * schemes pass; other web origins are rejected with a 403 HttpError; absent
+ * Origin (curl, native clients) passes.
+ */
+import * as chai from 'chai';
+import { CONFIG } from '../src/config/index.js';
+import { corsMiddleware } from '../src/middleware/cors.js';
+
+const { expect } = chai;
+
+/** Drive the cors package's origin callback via a fake request. */
+function decide(origin) {
+  return new Promise((resolve) => {
+    const req = { method: 'GET', headers: origin ? { origin } : {} };
+    const res = {
+      statusCode: 200,
+      setHeader() {},
+      getHeader() {},
+      end() {},
+    };
+    corsMiddleware(req, res, (err) => resolve(err ?? null));
+  });
+}
+
+describe('corsMiddleware origin policy', () => {
+  it('allows an allowlisted web origin', async function () {
+    // CONFIG reads env at import; the test env may run with an empty list.
+    const allowlisted = CONFIG.ALLOWED_ORIGINS[0];
+    if (!allowlisted) this.skip();
+    expect(await decide(allowlisted)).to.equal(null);
+  });
+
+  it('allows a chrome-extension origin without allowlisting', async () => {
+    expect(await decide('chrome-extension://abcdefghijklmnop')).to.equal(null);
+  });
+
+  it('allows a moz-extension origin', async () => {
+    expect(await decide('moz-extension://uuid-here')).to.equal(null);
+  });
+
+  it('allows an absent Origin header (curl, native clients)', async () => {
+    expect(await decide(undefined)).to.equal(null);
+  });
+
+  it('rejects an unlisted web origin with 403', async () => {
+    const err = await decide('https://evil.example');
+    expect(err).to.not.equal(null);
+    expect(err.status ?? err.statusCode).to.equal(403);
+  });
+
+  it('does not let a web page spoof the scheme mid-origin', async () => {
+    const err = await decide('https://chrome-extension.example');
+    expect(err).to.not.equal(null);
+  });
+});


### PR DESCRIPTION
Promotes the chrome-extension:// origin allowance to prod so the extension's default HTTPS RPC proxy works. dev==main otherwise.