### PR TITLE
fix(cors): review followups on the extension-scheme allowance

### DIFF
--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -14,7 +14,9 @@ export const corsMiddleware = cors({
     if (
       !origin ||
       CONFIG.ALLOWED_ORIGINS.includes(origin) ||
-      EXTENSION_SCHEMES.some((scheme) => origin.startsWith(scheme))
+      // Schemes are case-insensitive (RFC 6454); browsers normalize the
+      // Origin header to lowercase, but custom clients may not.
+      EXTENSION_SCHEMES.some((scheme) => origin.toLowerCase().startsWith(scheme))
     ) {
       callback(null, true);
     } else {

--- a/test/middleware.cors.test.js
+++ b/test/middleware.cors.test.js
@@ -24,11 +24,16 @@ function decide(origin) {
 }
 
 describe('corsMiddleware origin policy', () => {
-  it('allows an allowlisted web origin', async function () {
-    // CONFIG reads env at import; the test env may run with an empty list.
-    const allowlisted = CONFIG.ALLOWED_ORIGINS[0];
-    if (!allowlisted) this.skip();
-    expect(await decide(allowlisted)).to.equal(null);
+  it('allows an allowlisted web origin', async () => {
+    // CONFIG reads env at import and may be empty in the test env; inject a
+    // known entry so the allowlist branch is always exercised.
+    const testOrigin = 'https://allowed.example';
+    CONFIG.ALLOWED_ORIGINS.push(testOrigin);
+    try {
+      expect(await decide(testOrigin)).to.equal(null);
+    } finally {
+      CONFIG.ALLOWED_ORIGINS.splice(CONFIG.ALLOWED_ORIGINS.indexOf(testOrigin), 1);
+    }
   });
 
   it('allows a chrome-extension origin without allowlisting', async () => {
@@ -37,6 +42,10 @@ describe('corsMiddleware origin policy', () => {
 
   it('allows a moz-extension origin', async () => {
     expect(await decide('moz-extension://uuid-here')).to.equal(null);
+  });
+
+  it('allows extension origins with uppercase schemes (case-insensitive)', async () => {
+    expect(await decide('CHROME-EXTENSION://abcdefghijklmnop')).to.equal(null);
   });
 
   it('allows an absent Origin header (curl, native clients)', async () => {


### PR DESCRIPTION
Applies the three Gemini findings from #65: case-insensitive extension-scheme matching (RFC 6454), allowlist test no longer env-dependent (injects + removes its own origin), uppercase-scheme test added. Gates green (format:check, lint, typecheck, 92 mocha, build).