### PR TITLE
fix(security): harden RPC proxy and relay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Server Configuration
 PORT=3000
+LISTEN_HOST=127.0.0.1
 NODE_ENV=development
 
 # Cache Configuration
@@ -11,4 +12,29 @@ RPC_ENDPOINT_TESTNET=your_testnet_endpoint
 RPC_ENDPOINT_MAINNET=your_mainnet_endpoint
 
 # CORS Configuration
-ALLOWED_ORIGINS=https://example1.com,https://example2.com 
+ALLOWED_ORIGINS=https://example1.com,https://example2.com
+
+# Comma-separated proxy peer CIDRs allowed to supply X-Forwarded-For.
+# Production defaults to loopback for nginx-on-the-same-host. Development
+# defaults to no trusted proxies. Set explicit peer CIDRs for other topologies.
+TRUSTED_PROXY_CIDRS=
+
+# Networks that must have at least one actively advancing RPC endpoint for /health.
+RPC_REQUIRED_NETWORKS=testnet
+
+# RPC response and aggregate admission limits. RPC_MAX_INFLIGHT_BYTES must be
+# at least RPC_MAX_RESPONSE_BYTES or all upstream calls fail closed as busy.
+RPC_RATE_LIMIT_PER_MINUTE=1000
+RPC_WRITE_RATE_LIMIT_PER_MINUTE=10
+RPC_MAX_RESPONSE_BYTES=8388608
+RPC_MAX_CONCURRENT=16
+RPC_MAX_INFLIGHT_BYTES=67108864
+
+# IPFS and relay memory admission limits
+IPFS_FETCH_TIMEOUT_MS=8000
+IPFS_MAX_SIZE_BYTES=10485760
+IPFS_MAX_CONCURRENT=8
+IPFS_MAX_INFLIGHT_BYTES=41943040
+RELAY_MAX_BUFFERED_BYTES_PER_CHANNEL=2097152
+RELAY_MAX_BUFFERED_BYTES_PER_IP=8388608
+RELAY_MAX_BUFFERED_BYTES_GLOBAL=67108864

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ ENV PORT=3000
 
 # Health check using curl
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD curl -f http://localhost:3000/health || exit 1
+    CMD curl -f http://localhost:3000/health/live || exit 1
 
 # Start the server
 CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The backend provides two main services:
 
 ### Prerequisites
 
-- Node.js 18.x or later
+- Node.js 22.x
 - npm 9.x or later
 
 ### Installation
@@ -42,13 +42,14 @@ cp .env.example .env
 Edit `.env` with your settings:
 ```env
 PORT=3000
+LISTEN_HOST=127.0.0.1
 
 # RPC Endpoints
-RPC_URL_TESTNET=https://qrlwallet.com/api/qrl-rpc/testnet
-RPC_URL_MAINNET=https://qrlwallet.com/api/qrl-rpc/mainnet
+RPC_ENDPOINT_TESTNET=http://localhost:8545
+RPC_ENDPOINT_MAINNET=http://localhost:8545
 
 # CORS Origins
-CORS_ORIGINS=http://localhost:5173,https://qrlwallet.com
+ALLOWED_ORIGINS=http://localhost:5173,https://qrlwallet.com
 ```
 
 ### Development
@@ -68,7 +69,8 @@ npm run lint       # eslint (strict-type-checked)
 |--------|----------|-------------|
 | POST | `/api/qrl-rpc/:network` | Proxy RPC calls (network: testnet, mainnet) |
 | POST | `/api/tx-history` | Get transaction history for address |
-| GET | `/health` | Health check |
+| GET | `/health` | RPC readiness check |
+| GET | `/health/live` | Process liveness check |
 
 ### RPC Proxy Example
 
@@ -77,6 +79,18 @@ curl -X POST https://qrlwallet.com/api/qrl-rpc/testnet \
   -H "Content-Type: application/json" \
   -d '{"method": "qrl_blockNumber", "params": []}'
 ```
+
+Every RPC POST, including malformed JSON, rejected methods, and batches, consumes
+the general per-IP admission quota. Signed transaction submissions also use a
+stricter write quota. Upstream responses are streamed into a bounded parser:
+`RPC_MAX_RESPONSE_BYTES` caps one response, while `RPC_MAX_CONCURRENT` and
+`RPC_MAX_INFLIGHT_BYTES` cap process-wide admission. Saturation returns 503;
+oversized, invalid, or failed upstream responses return 502.
+
+Relay payloads use the same byte budgets for offline buffering and live
+transport delivery. A slow counterparty cannot grow Socket.IO's internal
+egress queue without bound; accepted buffered payloads are delivered on its
+next reconnect. Custom relay control events also share a per-IP rate limit.
 
 ### Transaction History Example
 
@@ -97,13 +111,21 @@ docker build -t myqrlwallet-backend:latest .
 ### Run Container
 
 ```bash
-docker run -d -p 3000:3000 myqrlwallet-backend:latest
+docker run -d \
+  -e LISTEN_HOST=0.0.0.0 \
+  -p 127.0.0.1:3000:3000 \
+  myqrlwallet-backend:latest
 ```
 
+The application binds to `127.0.0.1` by default. Containers must explicitly
+set `LISTEN_HOST=0.0.0.0`; publish the port only on host loopback or place it
+behind an isolated reverse proxy/ClusterIP. Configure `TRUSTED_PROXY_CIDRS`
+with the proxy peer CIDRs before accepting `X-Forwarded-For`.
+
 The container:
-- Uses Node.js 20 Alpine with non-root user (UID 1000)
+- Uses Node.js 22 Alpine with non-root user (UID 1000)
 - Serves on port 3000
-- Includes health check at `/health`
+- Includes process health check at `/health/live`
 - Has read-only root filesystem (security hardened)
 
 ## Kubernetes Deployment
@@ -143,6 +165,11 @@ kubectl apply -f k8s/hpa.yaml
 - Read-only root filesystem
 - `/tmp` mounted as emptyDir for temp files
 - No privilege escalation allowed
+
+The example ConfigMap deliberately targets an in-cluster `qrl-node` Service
+and disables mainnet. Replace that Service name with the actual trusted node
+topology before rollout. An RPC endpoint must never point back to the public
+wallet proxy because that creates a recursive request loop.
 
 ## CI/CD
 

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -13,12 +13,22 @@ metadata:
 data:
   NODE_ENV: "production"
   PORT: "3000"
-  # QRL RPC endpoints
-  QRL_RPC_TESTNET: "https://qrlwallet.com/api/qrl-rpc/testnet"
-  QRL_RPC_MAINNET: "https://qrlwallet.com/api/qrl-rpc/mainnet"
-  # ZondScan API for transaction history
-  ZONDSCAN_API_URL: "https://zondscan.com/api"
+  # ClusterIP provides the network boundary; containers must opt in to a pod-network bind.
+  LISTEN_HOST: "0.0.0.0"
+  # Keep empty until replaced with the ingress/reverse-proxy peer CIDRs.
+  TRUSTED_PROXY_CIDRS: ""
+  RPC_REQUIRED_NETWORKS: "testnet"
+  RPC_RATE_LIMIT_PER_MINUTE: "1000"
+  RPC_WRITE_RATE_LIMIT_PER_MINUTE: "10"
+  RPC_MAX_RESPONSE_BYTES: "8388608"
+  RPC_MAX_CONCURRENT: "16"
+  RPC_MAX_INFLIGHT_BYTES: "67108864"
+  # Replace qrl-node with the in-cluster node Service name. Never point this
+  # back at the public wallet proxy or requests recurse through the backend.
+  RPC_ENDPOINT_TESTNET: "http://qrl-node.myqrlwallet.svc.cluster.local:8545"
+  # Mainnet stays explicitly disabled until a separate trusted node is wired.
+  RPC_ENDPOINT_MAINNET: "http://127.0.0.1:9"
   # CORS allowed origins (comma-separated)
-  CORS_ORIGINS: "https://qrlwallet.com,https://www.qrlwallet.com"
+  ALLOWED_ORIGINS: "https://qrlwallet.com,https://www.qrlwallet.com"
   # Cache TTL in seconds
   CACHE_TTL: "60"

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -32,7 +32,7 @@ spec:
                 name: myqrlwallet-backend-config
           livenessProbe:
             httpGet:
-              path: /health
+              path: /health/live
               port: http
             initialDelaySeconds: 10
             periodSeconds: 10

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,20 +8,22 @@
       "name": "qrl-wallet-backend",
       "version": "1.0.0",
       "dependencies": {
-        "axios": "^1.16.0",
+        "axios": "^1.18.0",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.22.2",
-        "express-rate-limit": "^7.5.0",
+        "express-rate-limit": "^8.6.1",
         "node-cache": "^5.1.2",
         "pino": "^9.6.0",
         "prom-client": "^15.1.3",
+        "proxy-addr": "^2.0.7",
         "socket.io": "^4.8.3"
       },
       "devDependencies": {
         "@types/cors": "^2.8.19",
         "@types/express": "^4.17.25",
         "@types/node": "^22.19.21",
+        "@types/proxy-addr": "^2.0.3",
         "@typescript-eslint/eslint-plugin": "^8.61.0",
         "@typescript-eslint/parser": "^8.61.0",
         "chai": "^5.2.0",
@@ -109,9 +111,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -184,9 +186,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -491,6 +493,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/proxy-addr": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/proxy-addr/-/proxy-addr-2.0.3.tgz",
+      "integrity": "sha512-TgAHHO4tNG3HgLTUhB+hM4iwW6JUNeQHCLnF1DjaDA9c69PN+IasoFu2MYDhubFc+ZIw5c5t9DMtjvrD6R3Egg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -823,16 +835,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
@@ -974,6 +986,41 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agent-base/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agent-base/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -1090,13 +1137,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -1136,9 +1184,9 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -1189,9 +1237,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2127,9 +2175,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2321,10 +2369,14 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
-      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
+      "integrity": "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==",
       "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -2332,8 +2384,31 @@
         "url": "https://github.com/sponsors/express-rate-limit"
       },
       "peerDependencies": {
-        "express": "^4.11 || 5 || ^5.0.0-beta.1"
+        "express": ">= 4.11"
       }
+    },
+    "node_modules/express-rate-limit/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/express-rate-limit/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/fast-copy": {
       "version": "4.0.2",
@@ -2805,6 +2880,42 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -2871,6 +2982,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ip-regex": {
       "version": "5.0.0",
@@ -3971,9 +4091,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -20,20 +20,22 @@
     "format:check": "prettier --check 'src/**/*.ts' 'test/**/*.js' server.js"
   },
   "dependencies": {
-    "axios": "^1.16.0",
+    "axios": "^1.18.0",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.22.2",
-    "express-rate-limit": "^7.5.0",
+    "express-rate-limit": "^8.6.1",
     "node-cache": "^5.1.2",
     "pino": "^9.6.0",
     "prom-client": "^15.1.3",
+    "proxy-addr": "^2.0.7",
     "socket.io": "^4.8.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",
     "@types/express": "^4.17.25",
     "@types/node": "^22.19.21",
+    "@types/proxy-addr": "^2.0.3",
     "@typescript-eslint/eslint-plugin": "^8.61.0",
     "@typescript-eslint/parser": "^8.61.0",
     "chai": "^5.2.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,14 +1,19 @@
 import express from 'express';
 import { corsMiddleware } from './middleware/cors.js';
 import { errorHandler } from './middleware/error-handler.js';
+import { rpcRateLimitGeneral } from './middleware/rpc-security.js';
 import { routes } from './routes/index.js';
+import { isTrustedProxy } from './utils/client-ip.js';
 
 const app = express();
 
 // Middleware
-app.use(express.json());
+// Admit RPC traffic before parsing JSON so malformed and oversized bodies
+// consume the same per-IP quota as valid and application-rejected requests.
+app.use('/api/qrl-rpc/:network', rpcRateLimitGeneral);
+app.use(express.json({ limit: '50kb' }));
 app.use(corsMiddleware);
-app.set('trust proxy', 1); // Trust the first proxy
+app.set('trust proxy', isTrustedProxy);
 
 // Routes
 app.use(routes);

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -59,6 +59,7 @@ export interface RpcHealthConfig {
 
 export interface AppConfig {
   PORT: number;
+  LISTEN_HOST: string;
   NODE_ENV: string;
   LOG_LEVEL: string;
   CACHE_TTL: number;
@@ -66,15 +67,47 @@ export interface AppConfig {
   RELAY_MAX_ACTIVE_SOCKETS: number;
   RELAY_MAX_SOCKETS_PER_IP: number;
   RELAY_MAX_ACTIVE_CHANNELS: number;
+  RELAY_MAX_BUFFERED_BYTES_PER_CHANNEL: number;
+  RELAY_MAX_BUFFERED_BYTES_PER_IP: number;
+  RELAY_MAX_BUFFERED_BYTES_GLOBAL: number;
   RELAY_PING_INTERVAL_MS: number;
   RELAY_PING_TIMEOUT_MS: number;
+  TRUSTED_PROXY_CIDRS: string[];
   ALLOWED_ORIGINS: string[];
   RPC_ENDPOINTS: Record<NetworkName, string[]>;
+  RPC_REQUIRED_NETWORKS: NetworkName[];
   RPC_HEALTH: RpcHealthConfig;
+  RPC_RATE_LIMIT_PER_MINUTE: number;
+  RPC_WRITE_RATE_LIMIT_PER_MINUTE: number;
+  RPC_MAX_RESPONSE_BYTES: number;
+  RPC_MAX_CONCURRENT: number;
+  RPC_MAX_INFLIGHT_BYTES: number;
+  IPFS_FETCH_TIMEOUT_MS: number;
+  IPFS_MAX_SIZE_BYTES: number;
+  IPFS_MAX_CONCURRENT: number;
+  IPFS_MAX_INFLIGHT_BYTES: number;
+}
+
+export function resolveListenHost(value: string | undefined): string {
+  const host = value?.trim();
+  if (host === undefined || host.length === 0) return '127.0.0.1';
+  return host;
+}
+
+function parseRequiredNetworks(value: string | undefined): NetworkName[] {
+  const requested = (value ?? 'testnet')
+    .split(',')
+    .map((network) => network.trim().toLowerCase())
+    .filter(isNetworkName);
+  return Array.from(new Set(requested));
 }
 
 export const CONFIG: AppConfig = {
   PORT: parsePositiveInt(process.env.PORT, 3000),
+  // Binding to loopback is the safe default for the PM2 + local-nginx
+  // deployment. Containers that deliberately listen on their pod network
+  // must opt in with LISTEN_HOST=0.0.0.0.
+  LISTEN_HOST: resolveListenHost(process.env.LISTEN_HOST),
   NODE_ENV: process.env.NODE_ENV ?? 'development',
   LOG_LEVEL: process.env.LOG_LEVEL ?? '',
   CACHE_TTL: parseNonNegativeInt(process.env.CACHE_TTL, 10),
@@ -82,8 +115,31 @@ export const CONFIG: AppConfig = {
   RELAY_MAX_ACTIVE_SOCKETS: parsePositiveInt(process.env.RELAY_MAX_ACTIVE_SOCKETS, 5000),
   RELAY_MAX_SOCKETS_PER_IP: parsePositiveInt(process.env.RELAY_MAX_SOCKETS_PER_IP, 25),
   RELAY_MAX_ACTIVE_CHANNELS: parsePositiveInt(process.env.RELAY_MAX_ACTIVE_CHANNELS, 20000),
+  RELAY_MAX_BUFFERED_BYTES_PER_CHANNEL: parsePositiveInt(
+    process.env.RELAY_MAX_BUFFERED_BYTES_PER_CHANNEL,
+    2 * 1024 * 1024
+  ),
+  RELAY_MAX_BUFFERED_BYTES_PER_IP: parsePositiveInt(
+    process.env.RELAY_MAX_BUFFERED_BYTES_PER_IP,
+    8 * 1024 * 1024
+  ),
+  RELAY_MAX_BUFFERED_BYTES_GLOBAL: parsePositiveInt(
+    process.env.RELAY_MAX_BUFFERED_BYTES_GLOBAL,
+    64 * 1024 * 1024
+  ),
   RELAY_PING_INTERVAL_MS: parsePositiveInt(process.env.RELAY_PING_INTERVAL_MS, 25000),
   RELAY_PING_TIMEOUT_MS: parsePositiveInt(process.env.RELAY_PING_TIMEOUT_MS, 20000),
+
+  // Forwarding headers are ignored unless the direct peer matches one of
+  // these ranges. Production nginx runs on loopback; Cloudflare/other proxy
+  // ranges must be opted in explicitly when they connect to Node directly.
+  TRUSTED_PROXY_CIDRS: (
+    process.env.TRUSTED_PROXY_CIDRS ??
+    ((process.env.NODE_ENV ?? 'development') === 'production' ? 'loopback' : '')
+  )
+    .split(',')
+    .map((cidr) => cidr.trim())
+    .filter(Boolean),
 
   ALLOWED_ORIGINS: (process.env.ALLOWED_ORIGINS ?? '')
     .split(',')
@@ -95,6 +151,8 @@ export const CONFIG: AppConfig = {
     mainnet: parseEndpointList('MAINNET', ['http://localhost:8545']),
   },
 
+  RPC_REQUIRED_NETWORKS: parseRequiredNetworks(process.env.RPC_REQUIRED_NETWORKS),
+
   RPC_HEALTH: {
     POLL_INTERVAL_MS: parsePositiveInt(process.env.RPC_HEALTH_POLL_INTERVAL_MS, 10000),
     POLL_TIMEOUT_MS: parsePositiveInt(process.env.RPC_HEALTH_POLL_TIMEOUT_MS, 5000),
@@ -103,4 +161,18 @@ export const CONFIG: AppConfig = {
     UP_AFTER_SUCCESSES: parsePositiveInt(process.env.RPC_UP_AFTER_SUCCESSES, 3),
     STALL_AFTER_MS: parsePositiveInt(process.env.RPC_STALL_AFTER_MS, 300000), // 5 min
   },
+
+  RPC_RATE_LIMIT_PER_MINUTE: parsePositiveInt(process.env.RPC_RATE_LIMIT_PER_MINUTE, 1000),
+  RPC_WRITE_RATE_LIMIT_PER_MINUTE: parsePositiveInt(
+    process.env.RPC_WRITE_RATE_LIMIT_PER_MINUTE,
+    10
+  ),
+  RPC_MAX_RESPONSE_BYTES: parsePositiveInt(process.env.RPC_MAX_RESPONSE_BYTES, 8 * 1024 * 1024),
+  RPC_MAX_CONCURRENT: parsePositiveInt(process.env.RPC_MAX_CONCURRENT, 16),
+  RPC_MAX_INFLIGHT_BYTES: parsePositiveInt(process.env.RPC_MAX_INFLIGHT_BYTES, 64 * 1024 * 1024),
+
+  IPFS_FETCH_TIMEOUT_MS: parsePositiveInt(process.env.IPFS_FETCH_TIMEOUT_MS, 8000),
+  IPFS_MAX_SIZE_BYTES: parsePositiveInt(process.env.IPFS_MAX_SIZE_BYTES, 10 * 1024 * 1024),
+  IPFS_MAX_CONCURRENT: parsePositiveInt(process.env.IPFS_MAX_CONCURRENT, 8),
+  IPFS_MAX_INFLIGHT_BYTES: parsePositiveInt(process.env.IPFS_MAX_INFLIGHT_BYTES, 40 * 1024 * 1024),
 };

--- a/src/middleware/error-handler.ts
+++ b/src/middleware/error-handler.ts
@@ -11,13 +11,48 @@ function statusOf(err: unknown): number {
   return 500;
 }
 
-export const errorHandler = (err: unknown, _req: Request, res: Response, _next: NextFunction) => {
-  logger.error({ err }, 'Unhandled error');
-  const message = err instanceof Error && err.message ? err.message : 'Internal Server Error';
-  res.status(statusOf(err)).json({
+export const errorHandler = (err: unknown, _req: Request, res: Response, next: NextFunction) => {
+  if (res.headersSent) {
+    next(err);
+    return;
+  }
+
+  const status = statusOf(err);
+  const errorName = err instanceof Error ? err.name : typeof err;
+  const errorMessage = err instanceof Error && err.message ? err.message : 'Unknown error';
+  const isRequestParserError =
+    status < 500 &&
+    isRecord(err) &&
+    (typeof err.type === 'string' || (err instanceof SyntaxError && 'body' in err));
+  const safeErrorMessage = isRequestParserError
+    ? status === 413
+      ? 'Request body too large'
+      : 'Invalid request body'
+    : errorMessage;
+
+  // Do not pass the original object to the logger. body-parser errors carry
+  // the raw request in `err.body`, which can contain signed transactions or
+  // other wallet data when malformed JSON reaches this handler.
+  const logContext = {
+    status,
+    error: {
+      name: errorName,
+      message: safeErrorMessage,
+      ...(CONFIG.NODE_ENV === 'development' &&
+        !isRequestParserError &&
+        err instanceof Error && { stack: err.stack }),
+    },
+  };
+  if (status >= 500) logger.error(logContext, 'Unhandled server error');
+  else logger.warn(logContext, 'Rejected request');
+
+  const message = status >= 500 ? 'Internal Server Error' : safeErrorMessage;
+  res.status(status).json({
     error: {
       message,
-      ...(CONFIG.NODE_ENV === 'development' && err instanceof Error && { stack: err.stack }),
+      ...(CONFIG.NODE_ENV === 'development' &&
+        !isRequestParserError &&
+        err instanceof Error && { stack: err.stack }),
     },
   });
 };

--- a/src/middleware/rpc-security.ts
+++ b/src/middleware/rpc-security.ts
@@ -1,5 +1,6 @@
 import type { NextFunction, Request, Response } from 'express';
-import rateLimit from 'express-rate-limit';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
+import { CONFIG, isNetworkName } from '../config/index.js';
 import { normalizeRpcId, type RpcId } from '../services/rpc.service.js';
 import { isArray, isRecord } from '../utils/guards.js';
 import { logger } from '../utils/logger.js';
@@ -20,7 +21,6 @@ const ALLOWED_RPC_METHODS = new Set([
   'qrl_gasPrice',
   'qrl_estimateGas',
   'qrl_sendRawTransaction',
-  'qrl_sendTransaction',
   'qrl_getTransactionReceipt',
 
   // Contract Operations
@@ -38,7 +38,7 @@ const ALLOWED_RPC_METHODS = new Set([
 /**
  * Methods that modify state or are expensive - apply stricter rate limits
  */
-const WRITE_METHODS = new Set(['qrl_sendRawTransaction', 'qrl_sendTransaction']);
+const WRITE_METHODS = new Set(['qrl_sendRawTransaction']);
 
 /**
  * qrl_getLogs bounds. Without these a single request can ask the node to
@@ -67,15 +67,18 @@ function readRpcBody(req: Request): RpcRequestBody {
 }
 
 /**
- * Parse a hex block tag to a Number, or null for named tags / invalid input.
+ * Parse a canonical hex block tag without losing precision. Named tags and
+ * invalid values return null.
  */
-const parseBlockTag = (v: unknown): number | null => {
+const parseBlockTag = (v: unknown): bigint | null => {
   if (typeof v !== 'string') return null;
   if (v === 'latest' || v === 'pending' || v === 'earliest') return null;
-  if (!v.startsWith('0x')) return null;
-  const n = parseInt(v, 16);
-  return Number.isFinite(n) ? n : null;
+  if (!/^0x[0-9a-f]{1,64}$/i.test(v)) return null;
+  return BigInt(v);
 };
+
+const isNamedBlockTag = (v: unknown): boolean =>
+  v === 'latest' || v === 'pending' || v === 'earliest';
 
 /**
  * Helper function to send JSON-RPC error responses
@@ -120,8 +123,7 @@ export const rpcMethodWhitelist = (req: Request, res: Response, next: NextFuncti
 
   // Check if method is allowed
   if (!ALLOWED_RPC_METHODS.has(method)) {
-    log.warn({ method, ip: req.ip }, 'Blocked RPC method');
-    sendRpcError(res, 403, id, -32601, `Method not allowed: ${method}`);
+    sendRpcError(res, 403, id, -32601, 'Method not allowed');
     return;
   }
 
@@ -132,19 +134,24 @@ export const rpcMethodWhitelist = (req: Request, res: Response, next: NextFuncti
 };
 
 /**
- * Rate limiter for general RPC requests (read operations).
- * More lenient: 1000 requests per minute per IP.
+ * Admission limiter for every RPC request, including malformed, batched,
+ * disallowed, and write requests. This must run before request validation so
+ * rejected traffic cannot bypass admission accounting.
  */
 export const rpcRateLimitGeneral = rateLimit({
   windowMs: 60 * 1000, // 1 minute
-  max: 1000, // 1000 requests per minute per IP
+  limit: () => CONFIG.RPC_RATE_LIMIT_PER_MINUTE,
   standardHeaders: true,
   legacyHeaders: false,
   keyGenerator: (req) => {
-    // Use IP + network as key for more granular limiting
-    return `${req.ip ?? 'unknown'}-${req.params.network ?? 'unknown'}`;
+    // Collapse arbitrary path values into one bucket. Valid configured
+    // networks retain separate quotas without letting attackers rotate an
+    // unbounded `:network` string to bypass admission or grow the store.
+    const requestedNetwork = req.params.network ?? '';
+    const network = isNetworkName(requestedNetwork) ? requestedNetwork : 'invalid';
+    return `${ipKeyGenerator(req.ip ?? 'unknown')}-${network}`;
   },
-  skip: (req) => req.rpcMethodType === 'write', // Skip for write methods (they have their own limiter)
+  skip: (req) => req.method !== 'POST',
   handler: (req, res) => {
     sendRpcError(
       res,
@@ -158,15 +165,17 @@ export const rpcRateLimitGeneral = rateLimit({
 
 /**
  * Stricter rate limiter for write operations (sending transactions)
- * 10 transactions per minute per IP
+ * The configured limit is applied per IP and network.
  */
 export const rpcRateLimitWrite = rateLimit({
   windowMs: 60 * 1000, // 1 minute
-  max: 10, // 10 write operations per minute per IP
+  limit: () => CONFIG.RPC_WRITE_RATE_LIMIT_PER_MINUTE,
   standardHeaders: true,
   legacyHeaders: false,
   keyGenerator: (req) => {
-    return `${req.ip ?? 'unknown'}-write-${req.params.network ?? 'unknown'}`;
+    const requestedNetwork = req.params.network ?? '';
+    const network = isNetworkName(requestedNetwork) ? requestedNetwork : 'invalid';
+    return `${ipKeyGenerator(req.ip ?? 'unknown')}-write-${network}`;
   },
   skip: (req) => req.rpcMethodType !== 'write', // Only apply to write methods
   handler: (req, res) => {
@@ -179,22 +188,6 @@ export const rpcRateLimitWrite = rateLimit({
     );
   },
 });
-
-/**
- * Request size limiter - prevent oversized payloads
- * Max 50KB should be more than enough for any legitimate RPC call
- */
-export const rpcRequestSizeLimit = (req: Request, res: Response, next: NextFunction): void => {
-  const contentLength = parseInt(req.headers['content-length'] ?? '0', 10);
-  const MAX_SIZE = 50 * 1024; // 50KB
-
-  if (contentLength > MAX_SIZE) {
-    sendRpcError(res, 413, readRpcBody(req).id, -32600, 'Request payload too large');
-    return;
-  }
-
-  next();
-};
 
 /**
  * Validate params structure for known methods
@@ -234,8 +227,9 @@ export const rpcParamsValidator = (req: Request, res: Response, next: NextFuncti
         sendRpcError(res, 400, id, -32602, 'Invalid params: signed transaction required');
         return;
       }
-      // Validate it starts with 0x
-      if (!rawTx.startsWith('0x')) {
+      // Require canonical, byte-aligned hex rather than forwarding arbitrary
+      // text that happens to carry a 0x prefix.
+      if (!/^0x(?:[a-fA-F0-9]{2})+$/.test(rawTx)) {
         sendRpcError(res, 400, id, -32602, 'Invalid params: transaction must be hex-encoded');
         return;
       }
@@ -258,10 +252,9 @@ export const rpcParamsValidator = (req: Request, res: Response, next: NextFuncti
     }
 
     case 'qrl_call':
-    case 'qrl_estimateGas':
-    case 'qrl_sendTransaction': {
+    case 'qrl_estimateGas': {
       // These require a transaction object
-      if (!params || params.length < 1 || typeof params[0] !== 'object') {
+      if (!params || params.length < 1 || !isRecord(params[0])) {
         sendRpcError(res, 400, id, -32602, 'Invalid params: transaction object required');
         return;
       }
@@ -278,15 +271,45 @@ export const rpcParamsValidator = (req: Request, res: Response, next: NextFuncti
         return;
       }
 
-      if (typeof filter.blockHash !== 'string') {
+      if (filter.blockHash !== undefined && filter.blockHash !== null) {
+        if (
+          typeof filter.blockHash !== 'string' ||
+          !/^0x[a-fA-F0-9]{64}$/.test(filter.blockHash) ||
+          filter.fromBlock !== undefined ||
+          filter.toBlock !== undefined
+        ) {
+          sendRpcError(
+            res,
+            400,
+            id,
+            -32602,
+            'Invalid params: blockHash must be a 32-byte hash and cannot be combined with a range'
+          );
+          return;
+        }
+      } else {
         const from = parseBlockTag(filter.fromBlock);
         const to = parseBlockTag(filter.toBlock);
+
+        if (
+          (filter.fromBlock !== undefined &&
+            filter.fromBlock !== null &&
+            from === null &&
+            !isNamedBlockTag(filter.fromBlock)) ||
+          (filter.toBlock !== undefined &&
+            filter.toBlock !== null &&
+            to === null &&
+            !isNamedBlockTag(filter.toBlock))
+        ) {
+          sendRpcError(res, 400, id, -32602, 'Invalid params: invalid block tag');
+          return;
+        }
 
         // Open-ended scans from genesis are never legitimate. Compare on
         // the parsed numeric value so all hex variations of zero
         // ("0x0", "0x00", "0x000", ...) are caught; a literal-string
         // check would be trivially bypassable.
-        if (filter.fromBlock === 'earliest' || from === 0) {
+        if (filter.fromBlock === 'earliest' || from === 0n) {
           sendRpcError(
             res,
             400,
@@ -300,7 +323,7 @@ export const rpcParamsValidator = (req: Request, res: Response, next: NextFuncti
         // Both sides numeric → enforce the range cap directly.
         if (from !== null && to !== null) {
           const range = to - from;
-          if (range < 0 || range > MAX_GETLOGS_BLOCK_RANGE) {
+          if (range < 0n || range > BigInt(MAX_GETLOGS_BLOCK_RANGE)) {
             sendRpcError(
               res,
               400,
@@ -311,12 +334,24 @@ export const rpcParamsValidator = (req: Request, res: Response, next: NextFuncti
             return;
           }
         }
-        // Known gap: when `to` is "latest"/"pending" and `from` is a
-        // small-but-nonzero number, the range check is bypassed.
-        // Closing that requires querying current chain height from
-        // here (currently the middleware has no access to
-        // healthMonitor's lastHeight). Tracked for the next sprint;
-        // the genesis check above still covers the worst case.
+
+        // A numeric start combined with a dynamic or omitted end can cover
+        // an unbounded range. Require a numeric end so the cap above is
+        // enforceable without an extra upstream height lookup.
+        const dynamicEnd =
+          filter.toBlock === undefined ||
+          filter.toBlock === null ||
+          isNamedBlockTag(filter.toBlock);
+        if (from !== null && dynamicEnd) {
+          sendRpcError(
+            res,
+            400,
+            id,
+            -32602,
+            'Invalid params: numeric fromBlock requires a numeric toBlock'
+          );
+          return;
+        }
       }
 
       // Address filter: require the canonical QRL v2 form (Q + 40 hex
@@ -359,6 +394,12 @@ export const rpcParamsValidator = (req: Request, res: Response, next: NextFuncti
  */
 export const rpcSecurityLogger = (req: Request, res: Response, next: NextFunction): void => {
   const { method } = readRpcBody(req);
+  const loggedMethod =
+    typeof method === 'string'
+      ? method.length <= 128
+        ? method
+        : `${method.slice(0, 128)}...`
+      : undefined;
   const startTime = Date.now();
 
   // Log the request
@@ -368,7 +409,7 @@ export const rpcSecurityLogger = (req: Request, res: Response, next: NextFunctio
       timestamp: new Date().toISOString(),
       ip: req.ip,
       network: req.params.network,
-      method,
+      method: loggedMethod,
       statusCode: res.statusCode,
       duration: `${duration}ms`,
     };

--- a/src/relay/channelManager.ts
+++ b/src/relay/channelManager.ts
@@ -3,6 +3,8 @@
  * message buffering, and TTL cleanup for the QRL Connect protocol.
  */
 
+import { CONFIG } from '../config/index.js';
+
 const CHANNEL_TTL_MS = 30 * 60 * 1000; // 30 minutes inactivity
 const MAX_PARTICIPANTS = 2;
 const MAX_BUFFERED_MESSAGES = 50;
@@ -39,16 +41,28 @@ export interface Participant {
   joinedAt: number;
 }
 
+/** Exact message shape retained or relayed after wire validation. */
+export interface RelayPayload {
+  id: string;
+  clientType: ClientType;
+  message: unknown;
+  seq?: number;
+}
+
 interface BufferedMessage {
-  data: unknown;
+  data: RelayPayload;
   targetClientType: ClientType;
   timestamp: number;
+  sizeBytes: number;
+  sourceIp: string;
 }
 
 interface Channel {
   participants: Map<string, Participant>;
   lastActivity: number;
   messageBuffer: BufferedMessage[];
+  bufferedBytes: number;
+  directInflightBytes: number;
   /** Monotonic sequence numbers per sender socketId */
   seqNumbers: Map<string, number>;
   /** dApp's base64-encoded KEM public key. */
@@ -76,6 +90,7 @@ export type JoinResult = JoinSuccess | JoinFailure;
 
 export interface RouteResult {
   targetSocketId?: string;
+  backpressuredSocketId?: string;
   buffered: boolean;
   error?: string;
 }
@@ -84,10 +99,19 @@ export interface ChannelStats {
   activeChannels: number;
   totalParticipants: number;
   totalBufferedMessages: number;
+  totalBufferedBytes: number;
+  totalDirectInflightBytes: number;
 }
 
 export interface ChannelManagerOptions {
   isSocketActive?: (socketId: string) => boolean;
+  canSocketReceive?: (socketId: string) => boolean;
+}
+
+interface DirectDeliveryReservation {
+  channel: Channel;
+  sourceIp: string;
+  sizeBytes: number;
 }
 
 class ChannelManager {
@@ -95,10 +119,17 @@ class ChannelManager {
   /** FIFO of terminated channelIds, for tombstone eviction. */
   terminatedOrder: string[] = [];
   isSocketActive: (socketId: string) => boolean;
+  canSocketReceive: (socketId: string) => boolean;
+  totalBufferedBytes = 0;
+  totalDirectInflightBytes = 0;
+  directDeliveries = new Map<string, DirectDeliveryReservation>();
+  /** Combined buffered plus live-egress bytes retained on behalf of each IP. */
+  bufferedBytesByIp = new Map<string, number>();
   private cleanupTimer: NodeJS.Timeout | null;
 
   constructor(options: ChannelManagerOptions = {}) {
     this.isSocketActive = options.isSocketActive ?? (() => false);
+    this.canSocketReceive = options.canSocketReceive ?? (() => true);
     this.cleanupTimer = setInterval(() => {
       this.cleanup();
     }, CLEANUP_INTERVAL_MS);
@@ -126,6 +157,27 @@ class ChannelManager {
     clientType: ClientType,
     publicKeyBase64?: string
   ): JoinResult {
+    let canonicalPublicKey: string | undefined;
+    if (
+      clientType === 'dapp' &&
+      typeof publicKeyBase64 === 'string' &&
+      publicKeyBase64.length > 0
+    ) {
+      // Validate before allocating a channel. Otherwise invalid keys on fresh
+      // channel IDs leave empty channel records behind until the 30-minute TTL.
+      if (!/^[A-Za-z0-9+/]+={0,2}$/.test(publicKeyBase64)) {
+        return { success: false, error: 'Public key is not valid base64' };
+      }
+      const decoded = Buffer.from(publicKeyBase64, 'base64');
+      if (decoded.length === 0) {
+        return { success: false, error: 'Public key is empty' };
+      }
+      if (decoded.length > MAX_PUBLIC_KEY_BYTES) {
+        return { success: false, error: 'Public key exceeds size limit' };
+      }
+      canonicalPublicKey = decoded.toString('base64');
+    }
+
     let channel = this.channels.get(channelId);
 
     // Re-join to an explicitly closed channel: report the tombstone so the
@@ -148,12 +200,22 @@ class ChannelManager {
         participants: new Map<string, Participant>(),
         lastActivity: Date.now(),
         messageBuffer: [],
+        bufferedBytes: 0,
+        directInflightBytes: 0,
         seqNumbers: new Map<string, number>(),
         publicKey: null,
         terminated: false,
         terminatedAt: 0,
       };
       this.channels.set(channelId, channel);
+    }
+
+    const existingParticipant = channel.participants.get(socketId);
+    if (existingParticipant && existingParticipant.clientType !== clientType) {
+      return {
+        success: false,
+        error: 'A participant cannot change clientType while joined',
+      };
     }
 
     // Prevent active participant hijacking by requiring stale socket replacement only.
@@ -168,6 +230,7 @@ class ChannelManager {
         // Allow replacing stale/disconnected participant socket.
         channel.participants.delete(existingSocketId);
         channel.seqNumbers.delete(existingSocketId);
+        this.releaseDirectDelivery(existingSocketId);
         break;
       }
     }
@@ -180,31 +243,10 @@ class ChannelManager {
     // attempt (someone else trying to claim the same channelId with a
     // different PK) fails loudly instead of silently routing the wallet
     // to an attacker.
-    if (
-      clientType === 'dapp' &&
-      typeof publicKeyBase64 === 'string' &&
-      publicKeyBase64.length > 0
-    ) {
-      // Strict base64 validation up front. `Buffer.from(s, 'base64')`
-      // silently drops non-base64 characters instead of throwing, so we
-      // reject anything that doesn't match the canonical alphabet first.
-      // Re-encoding the decoded buffer and comparing to the input also
-      // canonicalises it; a dApp re-joining with equivalent-but-not-
-      // identical padding will still match the stored value byte-wise.
-      if (!/^[A-Za-z0-9+/]+={0,2}$/.test(publicKeyBase64)) {
-        return { success: false, error: 'Public key is not valid base64' };
-      }
-      const decoded = Buffer.from(publicKeyBase64, 'base64');
-      if (decoded.length === 0) {
-        return { success: false, error: 'Public key is empty' };
-      }
-      if (decoded.length > MAX_PUBLIC_KEY_BYTES) {
-        return { success: false, error: 'Public key exceeds size limit' };
-      }
-      const canonical = decoded.toString('base64');
+    if (canonicalPublicKey !== undefined) {
       if (channel.publicKey === null) {
-        channel.publicKey = canonical;
-      } else if (channel.publicKey !== canonical) {
+        channel.publicKey = canonicalPublicKey;
+      } else if (channel.publicKey !== canonicalPublicKey) {
         return {
           success: false,
           error: 'Channel is already bound to a different dApp public key',
@@ -228,6 +270,7 @@ class ChannelManager {
     for (const msg of channel.messageBuffer) {
       if (msg.targetClientType === clientType) {
         buffered.push(msg);
+        this.releaseBufferedBytes(channel, msg);
       } else {
         newBuffer.push(msg);
       }
@@ -279,6 +322,9 @@ class ChannelManager {
     // A terminated channel routes nothing, so drop its heavy state now rather
     // than holding it for TOMBSTONE_TTL_MS. The tombstone keeps only the
     // terminated flag + timestamps.
+    for (const message of channel.messageBuffer) {
+      this.releaseBufferedBytes(channel, message);
+    }
     channel.messageBuffer = [];
     channel.participants.clear();
     channel.seqNumbers.clear();
@@ -321,7 +367,12 @@ class ChannelManager {
    * Route a message to the counterparty in the channel.
    * If counterparty is disconnected, buffer the message.
    */
-  routeMessage(channelId: string, senderSocketId: string, data: unknown): RouteResult {
+  routeMessage(
+    channelId: string,
+    senderSocketId: string,
+    data: RelayPayload,
+    sourceIp = 'unknown'
+  ): RouteResult {
     const channel = this.channels.get(channelId);
     if (!channel) {
       return { buffered: false, error: 'Channel not found' };
@@ -334,24 +385,29 @@ class ChannelManager {
       return { buffered: false, error: 'Channel terminated' };
     }
 
-    channel.lastActivity = Date.now();
-
     const sender = channel.participants.get(senderSocketId);
     if (!sender) {
       return { buffered: false, error: 'Sender not in channel' };
     }
 
+    if (data.clientType !== sender.clientType) {
+      return { buffered: false, error: 'clientType does not match channel participant' };
+    }
+
+    channel.lastActivity = Date.now();
+
     // Replay protection: enforce monotonic sequence numbers per sender.
     // If the message includes a seq number, reject duplicates and out-of-order.
-    if (typeof data === 'object' && data !== null && 'seq' in data) {
-      const seq = data.seq;
-      if (typeof seq === 'number') {
-        const lastSeq = channel.seqNumbers.get(senderSocketId) ?? -1;
-        if (seq <= lastSeq) {
-          return { buffered: false, error: 'Duplicate or out-of-order message (replay rejected)' };
-        }
-        channel.seqNumbers.set(senderSocketId, seq);
+    if (data.seq !== undefined) {
+      const lastSeq = channel.seqNumbers.get(senderSocketId) ?? -1;
+      if (data.seq <= lastSeq) {
+        return { buffered: false, error: 'Duplicate or out-of-order message (replay rejected)' };
       }
+    }
+
+    const sizeBytes = this.getSerializedSize(data);
+    if (sizeBytes === null) {
+      return { buffered: false, error: 'Message payload is not serializable' };
     }
 
     // Find counterparty (the other participant)
@@ -364,25 +420,137 @@ class ChannelManager {
       }
     }
 
-    if (targetSocketId) {
-      return { targetSocketId, buffered: false };
+    if (targetSocketId && this.canSocketReceive(targetSocketId)) {
+      const sourceBytes = this.bufferedBytesByIp.get(sourceIp) ?? 0;
+      if (
+        !this.directDeliveries.has(targetSocketId) &&
+        channel.bufferedBytes + channel.directInflightBytes + sizeBytes <=
+          CONFIG.RELAY_MAX_BUFFERED_BYTES_PER_CHANNEL &&
+        sourceBytes + sizeBytes <= CONFIG.RELAY_MAX_BUFFERED_BYTES_PER_IP &&
+        this.totalBufferedBytes + this.totalDirectInflightBytes + sizeBytes <=
+          CONFIG.RELAY_MAX_BUFFERED_BYTES_GLOBAL
+      ) {
+        const reservation = { channel, sourceIp, sizeBytes };
+        this.directDeliveries.set(targetSocketId, reservation);
+        channel.directInflightBytes += sizeBytes;
+        this.totalDirectInflightBytes += sizeBytes;
+        this.retainIpBytes(sourceIp, sizeBytes);
+        if (data.seq !== undefined) channel.seqNumbers.set(senderSocketId, data.seq);
+        return { targetSocketId, buffered: false };
+      }
     }
 
-    // Counterparty not connected - buffer the message
+    // Counterparty is absent or its transport cannot accept a bounded direct
+    // delivery. Retain the payload under the offline budgets. The server
+    // disconnects a backpressured live target so its normal reconnect drains
+    // this buffer instead of leaving an accepted payload parked indefinitely.
+    const backpressuredSocketId = targetSocketId ?? undefined;
+    const backpressureContext = backpressuredSocketId ? { backpressuredSocketId } : {};
     const otherClientType: ClientType = sender.clientType === 'dapp' ? 'wallet' : 'dapp';
 
-    if (channel.messageBuffer.length >= MAX_BUFFERED_MESSAGES) {
-      // Drop oldest message
-      channel.messageBuffer.shift();
+    // Preserve the message-count cap by evicting the oldest entry, but account
+    // for that prospective removal before evaluating all byte budgets.
+    const oldest =
+      channel.messageBuffer.length >= MAX_BUFFERED_MESSAGES ? channel.messageBuffer[0] : undefined;
+    const oldestSize = oldest?.sizeBytes ?? 0;
+    const sourceBytes = this.bufferedBytesByIp.get(sourceIp) ?? 0;
+    const sourceOldestSize = oldest?.sourceIp === sourceIp ? oldestSize : 0;
+    const channelBytesAfter =
+      channel.bufferedBytes + channel.directInflightBytes - oldestSize + sizeBytes;
+    const sourceBytesAfter = sourceBytes - sourceOldestSize + sizeBytes;
+    const globalBytesAfter =
+      this.totalBufferedBytes + this.totalDirectInflightBytes - oldestSize + sizeBytes;
+
+    if (channelBytesAfter > CONFIG.RELAY_MAX_BUFFERED_BYTES_PER_CHANNEL) {
+      return {
+        ...backpressureContext,
+        buffered: false,
+        error: 'Channel buffered-byte capacity exceeded',
+      };
+    }
+    if (sourceBytesAfter > CONFIG.RELAY_MAX_BUFFERED_BYTES_PER_IP) {
+      return {
+        ...backpressureContext,
+        buffered: false,
+        error: 'Per-IP buffered-byte capacity exceeded',
+      };
+    }
+    if (globalBytesAfter > CONFIG.RELAY_MAX_BUFFERED_BYTES_GLOBAL) {
+      return {
+        ...backpressureContext,
+        buffered: false,
+        error: 'Global buffered-byte capacity exceeded',
+      };
     }
 
-    channel.messageBuffer.push({
+    if (oldest) {
+      channel.messageBuffer.shift();
+      this.releaseBufferedBytes(channel, oldest);
+    }
+
+    const bufferedMessage: BufferedMessage = {
       data,
       targetClientType: otherClientType,
       timestamp: Date.now(),
-    });
+      sizeBytes,
+      sourceIp,
+    };
+    channel.messageBuffer.push(bufferedMessage);
+    this.retainBufferedBytes(channel, bufferedMessage);
+    if (data.seq !== undefined) channel.seqNumbers.set(senderSocketId, data.seq);
 
-    return { buffered: true };
+    return { ...backpressureContext, buffered: true };
+  }
+
+  /** Release the one bounded live-egress reservation for a target socket. */
+  releaseDirectDelivery(socketId: string): void {
+    const reservation = this.directDeliveries.get(socketId);
+    if (!reservation) return;
+    this.directDeliveries.delete(socketId);
+    reservation.channel.directInflightBytes = Math.max(
+      0,
+      reservation.channel.directInflightBytes - reservation.sizeBytes
+    );
+    this.totalDirectInflightBytes = Math.max(
+      0,
+      this.totalDirectInflightBytes - reservation.sizeBytes
+    );
+    this.releaseIpBytes(reservation.sourceIp, reservation.sizeBytes);
+  }
+
+  hasDirectDelivery(socketId: string): boolean {
+    return this.directDeliveries.has(socketId);
+  }
+
+  private getSerializedSize(data: RelayPayload): number | null {
+    try {
+      const serialized = JSON.stringify(data);
+      return typeof serialized === 'string' ? Buffer.byteLength(serialized, 'utf8') : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private retainBufferedBytes(channel: Channel, message: BufferedMessage): void {
+    channel.bufferedBytes += message.sizeBytes;
+    this.totalBufferedBytes += message.sizeBytes;
+    this.retainIpBytes(message.sourceIp, message.sizeBytes);
+  }
+
+  private releaseBufferedBytes(channel: Channel, message: BufferedMessage): void {
+    channel.bufferedBytes = Math.max(0, channel.bufferedBytes - message.sizeBytes);
+    this.totalBufferedBytes = Math.max(0, this.totalBufferedBytes - message.sizeBytes);
+    this.releaseIpBytes(message.sourceIp, message.sizeBytes);
+  }
+
+  private retainIpBytes(sourceIp: string, sizeBytes: number): void {
+    this.bufferedBytesByIp.set(sourceIp, (this.bufferedBytesByIp.get(sourceIp) ?? 0) + sizeBytes);
+  }
+
+  private releaseIpBytes(sourceIp: string, sizeBytes: number): void {
+    const ipBytes = (this.bufferedBytesByIp.get(sourceIp) ?? 0) - sizeBytes;
+    if (ipBytes > 0) this.bufferedBytesByIp.set(sourceIp, ipBytes);
+    else this.bufferedBytesByIp.delete(sourceIp);
   }
 
   /**
@@ -424,10 +592,14 @@ class ChannelManager {
     const now = Date.now();
 
     for (const [channelId, channel] of this.channels) {
-      // Remove expired buffered messages
-      channel.messageBuffer = channel.messageBuffer.filter(
-        (msg) => now - msg.timestamp < BUFFER_TTL_MS
-      );
+      // Remove expired buffered messages and release every byte-accounting
+      // bucket at the same time.
+      const retained: BufferedMessage[] = [];
+      for (const message of channel.messageBuffer) {
+        if (now - message.timestamp < BUFFER_TTL_MS) retained.push(message);
+        else this.releaseBufferedBytes(channel, message);
+      }
+      channel.messageBuffer = retained;
 
       // Terminated tombstones live on their own (longer) TTL so a dApp that
       // re-joins within a day still learns the session was closed on purpose.
@@ -470,6 +642,8 @@ class ChannelManager {
       activeChannels: this.channels.size,
       totalParticipants,
       totalBufferedMessages: totalBuffered,
+      totalBufferedBytes: this.totalBufferedBytes,
+      totalDirectInflightBytes: this.totalDirectInflightBytes,
     };
   }
 
@@ -495,6 +669,10 @@ class ChannelManager {
       clearInterval(this.cleanupTimer);
       this.cleanupTimer = null;
     }
+    this.totalBufferedBytes = 0;
+    this.totalDirectInflightBytes = 0;
+    this.directDeliveries.clear();
+    this.bufferedBytesByIp.clear();
   }
 }
 

--- a/src/relay/metrics.ts
+++ b/src/relay/metrics.ts
@@ -29,6 +29,18 @@ export const bufferedMessages = new Gauge({
   registers: [register],
 });
 
+export const bufferedBytes = new Gauge({
+  name: 'relay_buffered_bytes',
+  help: 'Total buffered relay payload bytes across all channels',
+  registers: [register],
+});
+
+export const directInflightBytes = new Gauge({
+  name: 'relay_direct_inflight_bytes',
+  help: 'Relay payload bytes reserved until target transport drain',
+  registers: [register],
+});
+
 // --- Counters (cumulative) ---
 
 export const messagesRouted = new Counter({

--- a/src/relay/relayServer.ts
+++ b/src/relay/relayServer.ts
@@ -8,16 +8,24 @@
  */
 
 import type { Server as HttpServer } from 'node:http';
+import type { Transport } from 'engine.io';
 import { Server } from 'socket.io';
-import { ChannelManager, isClientType, type ClientType } from './channelManager.js';
+import {
+  ChannelManager,
+  isClientType,
+  type ClientType,
+  type RelayPayload,
+} from './channelManager.js';
 import { CONFIG } from '../config/index.js';
-import { isArray, isRecord } from '../utils/guards.js';
+import { getTrustedClientIp, normalizeClientIpForLimits } from '../utils/client-ip.js';
+import { isRecord } from '../utils/guards.js';
 import * as metrics from './metrics.js';
 
 const RATE_LIMIT_WINDOW_MS = 60 * 1000; // 1 minute
 const RATE_LIMIT_MAX_MESSAGES = 100; // per window per IP
 const RATE_LIMIT_MAX_JOINS = 30; // per window per IP
 const RATE_LIMIT_MAX_CONNECTIONS = 60; // new connections per window per IP
+const RATE_LIMIT_MAX_CONTROL_EVENTS = 300; // ping/leave/close per window per IP
 const MAX_CHANNEL_ID_LENGTH = 128;
 const CHANNEL_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 const MAX_MESSAGE_BYTES = 256 * 1024;
@@ -105,12 +113,52 @@ export function createRelayServer(httpServer: HttpServer): RelayHandle {
     maxHttpBufferSize: MAX_MESSAGE_BYTES,
   });
 
+  const directDrainListeners = new Map<string, { transport: Transport; onDrain: () => void }>();
+  const disconnectAfterDrain = new Set<string>();
+
   const channelManager = new ChannelManager({
     isSocketActive: (socketId) => io.sockets.sockets.has(socketId),
+    canSocketReceive: (socketId) => {
+      const target = io.sockets.sockets.get(socketId);
+      return (
+        target?.connected === true &&
+        target.conn.readyState === 'open' &&
+        target.conn.transport.writable &&
+        !directDrainListeners.has(socketId)
+      );
+    },
   });
 
+  function releaseDirectDelivery(socketId: string): void {
+    const armed = directDrainListeners.get(socketId);
+    if (armed) {
+      armed.transport.removeListener('drain', armed.onDrain);
+      directDrainListeners.delete(socketId);
+    }
+    disconnectAfterDrain.delete(socketId);
+    channelManager.releaseDirectDelivery(socketId);
+  }
+
+  function armDirectDelivery(socketId: string): boolean {
+    const target = io.sockets.sockets.get(socketId);
+    if (!target?.connected || target.conn.readyState !== 'open') return false;
+    const transport = target.conn.transport;
+    if (!transport.writable || directDrainListeners.has(socketId)) return false;
+
+    const onDrain = (): void => {
+      directDrainListeners.delete(socketId);
+      channelManager.releaseDirectDelivery(socketId);
+      if (disconnectAfterDrain.delete(socketId)) {
+        io.sockets.sockets.get(socketId)?.disconnect(true);
+      }
+    };
+    directDrainListeners.set(socketId, { transport, onDrain });
+    transport.once('drain', onDrain);
+    return true;
+  }
+
   interface RateLimitEntry {
-    counts: { connect: number; message: number; join: number };
+    counts: { connect: number; message: number; join: number; control: number };
     resetAt: number;
   }
   const rateLimits = new Map<string, RateLimitEntry>();
@@ -128,7 +176,10 @@ export function createRelayServer(httpServer: HttpServer): RelayHandle {
     let entry = rateLimits.get(ip);
 
     if (!entry || now > entry.resetAt) {
-      entry = { counts: { connect: 0, message: 0, join: 0 }, resetAt: now + RATE_LIMIT_WINDOW_MS };
+      entry = {
+        counts: { connect: 0, message: 0, join: 0, control: 0 },
+        resetAt: now + RATE_LIMIT_WINDOW_MS,
+      };
       rateLimits.set(ip, entry);
     }
 
@@ -141,59 +192,21 @@ export function createRelayServer(httpServer: HttpServer): RelayHandle {
    */
   function getMessageSizeBytes(message: unknown): number {
     try {
-      if (typeof message === 'string') {
-        return Buffer.byteLength(message, 'utf8');
-      }
-      if (typeof message === 'object' && message !== null) {
-        return Buffer.byteLength(JSON.stringify(message), 'utf8');
-      }
-      return 0;
+      const serialized = JSON.stringify(message);
+      return typeof serialized === 'string'
+        ? Buffer.byteLength(serialized, 'utf8')
+        : MAX_MESSAGE_BYTES + 1;
     } catch {
       return MAX_MESSAGE_BYTES + 1;
     }
   }
 
-  /**
-   * Normalize a client IP string from proxy/socket metadata.
-   */
-  function normalizeClientIp(rawIp: unknown): string {
-    if (typeof rawIp !== 'string') return '';
-    const trimmed = rawIp.trim();
-    if (!trimmed) return '';
-    if (trimmed.startsWith('::ffff:')) {
-      return trimmed.slice('::ffff:'.length);
-    }
-    return trimmed;
-  }
-
-  /**
-   * Resolve client IP for rate limiting across direct and proxied setups.
-   */
-  function getClientIp(socket: {
-    handshake: { headers: Record<string, unknown>; address: string };
-    conn: { remoteAddress: string };
-  }): string {
-    const headers = socket.handshake.headers;
-    const xff = headers['x-forwarded-for'];
-    const forwardedFor = typeof xff === 'string' ? xff.split(',')[0] : isArray(xff) ? xff[0] : '';
-
-    const candidates: unknown[] = [
-      headers['cf-connecting-ip'],
-      headers['true-client-ip'],
-      headers['x-real-ip'],
-      forwardedFor,
-      socket.handshake.address,
-      socket.conn.remoteAddress,
-    ];
-
-    for (const candidate of candidates) {
-      const normalized = normalizeClientIp(candidate);
-      if (normalized) {
-        return normalized;
-      }
-    }
-
-    return 'unknown';
+  function refreshBufferMetrics(): void {
+    const stats = channelManager.getStats();
+    metrics.activeChannels.set(channelManager.getActiveChannelCount());
+    metrics.bufferedMessages.set(stats.totalBufferedMessages);
+    metrics.bufferedBytes.set(stats.totalBufferedBytes);
+    metrics.directInflightBytes.set(stats.totalDirectInflightBytes);
   }
 
   // Cleanup rate limit entries periodically
@@ -204,10 +217,11 @@ export function createRelayServer(httpServer: HttpServer): RelayHandle {
         rateLimits.delete(ip);
       }
     }
+    refreshBufferMetrics();
   }, RATE_LIMIT_WINDOW_MS);
 
   io.on('connection', (socket) => {
-    const clientIp = getClientIp(socket);
+    const clientIp = normalizeClientIpForLimits(getTrustedClientIp(socket.request));
 
     if (!checkRateLimit(clientIp, 'connect', RATE_LIMIT_MAX_CONNECTIONS)) {
       metrics.rateLimitHits.inc({ bucket: 'connect' });
@@ -242,6 +256,7 @@ export function createRelayServer(httpServer: HttpServer): RelayHandle {
     metrics.activeSockets.inc();
     let currentChannelId: string | null = null;
     let releasedSocketCounter = false;
+    let joinInProgress = false;
 
     const releaseSocketCounter = (): void => {
       if (releasedSocketCounter) {
@@ -264,95 +279,130 @@ export function createRelayServer(httpServer: HttpServer): RelayHandle {
      * The relay binds it to the channel and echoes it back to the wallet
      * on its join so the wallet can verify the fingerprint from the QR.
      */
-    socket.on('join_channel', (payload, rawCallback) => {
+    socket.on('join_channel', async (payload, rawCallback) => {
       const callback = toAck(rawCallback);
-      if (!checkRateLimit(clientIp, 'join', RATE_LIMIT_MAX_JOINS)) {
-        metrics.rateLimitHits.inc({ bucket: 'join' });
-        callback?.({ success: false, error: 'Join rate limit exceeded' });
+      if (joinInProgress) {
+        callback?.({ success: false, error: 'Another channel join is in progress' });
         return;
       }
+      joinInProgress = true;
+      let joinedRoom = false;
+      let joinedManager = false;
+      let requestedChannelId: string | null = null;
+      try {
+        if (!checkRateLimit(clientIp, 'join', RATE_LIMIT_MAX_JOINS)) {
+          metrics.rateLimitHits.inc({ bucket: 'join' });
+          callback?.({ success: false, error: 'Join rate limit exceeded' });
+          return;
+        }
 
-      const data = isRecord(payload) ? payload : {};
-      const channelId = data.channelId;
-      const clientType = data.clientType;
-      const publicKey = data.publicKey;
+        const data = isRecord(payload) ? payload : {};
+        const channelId = data.channelId;
+        const clientType = data.clientType;
+        const publicKey = data.publicKey;
 
-      if (!isValidChannelId(channelId)) {
-        callback?.({ success: false, error: 'Invalid channelId' });
-        return;
-      }
-      if (
-        !channelManager.getChannelInfo(channelId) &&
-        channelManager.getActiveChannelCount() >= CONFIG.RELAY_MAX_ACTIVE_CHANNELS
-      ) {
-        callback?.({ success: false, error: 'Relay channel capacity reached' });
-        return;
-      }
+        if (!isValidChannelId(channelId)) {
+          callback?.({ success: false, error: 'Invalid channelId' });
+          return;
+        }
+        requestedChannelId = channelId;
+        if (
+          !channelManager.getChannelInfo(channelId) &&
+          channelManager.getActiveChannelCount() >= CONFIG.RELAY_MAX_ACTIVE_CHANNELS
+        ) {
+          callback?.({ success: false, error: 'Relay channel capacity reached' });
+          return;
+        }
 
-      if (!isClientType(clientType)) {
-        callback?.({
-          success: false,
-          error: 'clientType must be "dapp" or "wallet"',
+        if (!isClientType(clientType)) {
+          callback?.({
+            success: false,
+            error: 'clientType must be "dapp" or "wallet"',
+          });
+          return;
+        }
+
+        if (publicKey !== undefined && typeof publicKey !== 'string') {
+          callback?.({ success: false, error: 'publicKey must be a base64 string' });
+          return;
+        }
+
+        const switchingChannels = currentChannelId !== null && currentChannelId !== channelId;
+        if (currentChannelId !== channelId) {
+          await socket.join(channelId);
+          joinedRoom = true;
+        }
+
+        const result = channelManager.join(channelId, socket.id, clientType, publicKey);
+
+        if (!result.success) {
+          if (joinedRoom) await socket.leave(channelId);
+          callback?.({ success: false, error: result.error });
+          return;
+        }
+
+        // Re-join to an explicitly closed (tombstoned) channel: report the
+        // tombstone so the peer drops its stored session, but do NOT park the
+        // socket in the dead room, point currentChannelId at it, or emit a
+        // phantom 'join'. channelManager.join() added no participant for a
+        // terminated channel and routing is refused there, so joining the room
+        // would only leak a spurious presence event to other re-joiners.
+        if (result.terminated) {
+          if (joinedRoom) await socket.leave(channelId);
+          callback?.({
+            success: true,
+            terminated: true,
+            participants: [],
+            channelPublicKey: null,
+            bufferedMessages: [],
+          });
+          return;
+        }
+        joinedManager = true;
+
+        if (switchingChannels && currentChannelId) {
+          const previousChannelId = currentChannelId;
+          const previousParticipant = channelManager.leave(socket.id, previousChannelId);
+          if (previousParticipant) {
+            socket.to(previousChannelId).emit('participants_changed', {
+              event: 'leave',
+              clientType: previousParticipant.clientType,
+            });
+          }
+          await socket.leave(previousChannelId);
+        }
+
+        metrics.channelJoins.inc({ status: 'success' });
+        refreshBufferMetrics();
+        currentChannelId = channelId;
+
+        // Notify other participant that counterparty joined
+        socket.to(channelId).emit('participants_changed', {
+          event: 'join',
+          clientType,
         });
-        return;
-      }
 
-      if (publicKey !== undefined && typeof publicKey !== 'string') {
-        callback?.({ success: false, error: 'publicKey must be a base64 string' });
-        return;
-      }
-
-      // Leave previous channel if any
-      if (currentChannelId && currentChannelId !== channelId) {
-        void socket.leave(currentChannelId);
-        channelManager.leave(socket.id, currentChannelId);
-      }
-
-      const result = channelManager.join(channelId, socket.id, clientType, publicKey);
-
-      if (!result.success) {
-        callback?.({ success: false, error: result.error });
-        return;
-      }
-
-      // Re-join to an explicitly closed (tombstoned) channel: report the
-      // tombstone so the peer drops its stored session, but do NOT park the
-      // socket in the dead room, point currentChannelId at it, or emit a
-      // phantom 'join'. channelManager.join() added no participant for a
-      // terminated channel and routing is refused there, so joining the room
-      // would only leak a spurious presence event to other re-joiners.
-      if (result.terminated) {
         callback?.({
           success: true,
-          terminated: true,
-          participants: [],
-          channelPublicKey: null,
-          bufferedMessages: [],
+          bufferedMessages: result.bufferedMessages,
+          channelPublicKey: result.channelPublicKey,
+          // Counterparty roster so a (re)joining peer can detect an absent
+          // wallet immediately; `terminated` flags a channel that was closed
+          // on purpose so the peer drops its stored session instead of waiting.
+          participants: result.participants,
+          terminated: result.terminated,
         });
-        return;
+      } catch {
+        if (joinedManager && requestedChannelId) {
+          channelManager.leave(socket.id, requestedChannelId);
+        }
+        if (joinedRoom && requestedChannelId) {
+          await Promise.resolve(socket.leave(requestedChannelId)).catch(() => undefined);
+        }
+        callback?.({ success: false, error: 'Unable to join channel' });
+      } finally {
+        joinInProgress = false;
       }
-
-      void socket.join(channelId);
-      metrics.channelJoins.inc({ status: 'success' });
-      metrics.activeChannels.set(channelManager.getActiveChannelCount());
-      currentChannelId = channelId;
-
-      // Notify other participant that counterparty joined
-      socket.to(channelId).emit('participants_changed', {
-        event: 'join',
-        clientType,
-      });
-
-      callback?.({
-        success: true,
-        bufferedMessages: result.bufferedMessages,
-        channelPublicKey: result.channelPublicKey,
-        // Counterparty roster so a (re)joining peer can detect an absent
-        // wallet immediately; `terminated` flags a channel that was closed
-        // on purpose so the peer drops its stored session instead of waiting.
-        participants: result.participants,
-        terminated: result.terminated,
-      });
     });
 
     /**
@@ -370,17 +420,43 @@ export function createRelayServer(httpServer: HttpServer): RelayHandle {
       const data = isRecord(payload) ? payload : {};
       const channelId = data.id;
       const message = data.message;
+      const clientType = data.clientType;
+      const seq = data.seq;
 
-      if (!isValidChannelId(channelId) || !message) {
-        callback?.({ success: false, error: 'Invalid channelId or missing message' });
+      if (
+        !isValidChannelId(channelId) ||
+        message === undefined ||
+        message === null ||
+        !isClientType(clientType)
+      ) {
+        callback?.({ success: false, error: 'Invalid channelId, clientType, or missing message' });
         return;
       }
-      if (getMessageSizeBytes(message) > MAX_MESSAGE_BYTES) {
+      if (seq !== undefined && (typeof seq !== 'number' || !Number.isSafeInteger(seq) || seq < 0)) {
+        callback?.({ success: false, error: 'seq must be a non-negative safe integer' });
+        return;
+      }
+
+      const payloadSize = getMessageSizeBytes(payload);
+      if (payloadSize > MAX_MESSAGE_BYTES) {
         callback?.({ success: false, error: 'Message payload too large' });
         return;
       }
 
-      const result = channelManager.routeMessage(channelId, socket.id, payload);
+      const canonicalPayload: RelayPayload =
+        seq === undefined
+          ? { id: channelId, clientType, message }
+          : { id: channelId, clientType, message, seq };
+      const result = channelManager.routeMessage(channelId, socket.id, canonicalPayload, clientIp);
+
+      if (result.backpressuredSocketId !== undefined) {
+        const slowTarget = io.sockets.sockets.get(result.backpressuredSocketId);
+        if (channelManager.hasDirectDelivery(result.backpressuredSocketId)) {
+          disconnectAfterDrain.add(result.backpressuredSocketId);
+        } else {
+          slowTarget?.disconnect(true);
+        }
+      }
 
       if (result.error !== undefined) {
         callback?.({ success: false, error: result.error });
@@ -388,10 +464,19 @@ export function createRelayServer(httpServer: HttpServer): RelayHandle {
       }
 
       if (result.targetSocketId !== undefined) {
-        // Deliver directly to counterparty
-        io.to(result.targetSocketId).emit('message', payload);
+        const target = io.sockets.sockets.get(result.targetSocketId);
+        if (!target || !armDirectDelivery(result.targetSocketId)) {
+          releaseDirectDelivery(result.targetSocketId);
+          target?.disconnect(true);
+          callback?.({ success: false, error: 'Counterparty transport unavailable' });
+          return;
+        }
+        // The transport was writable at admission and the delivery is reserved
+        // until its actual transport drain. Volatile is a final race guard: it
+        // prevents Socket.IO from silently creating a second unaccounted queue.
+        target.volatile.emit('message', canonicalPayload);
         metrics.messagesRouted.inc({ status: 'delivered' });
-        metrics.messageSize.observe(getMessageSizeBytes(message));
+        metrics.messageSize.observe(payloadSize);
       }
 
       callback?.({ success: true, buffered: result.buffered });
@@ -405,6 +490,11 @@ export function createRelayServer(httpServer: HttpServer): RelayHandle {
      */
     socket.on('leave_channel', (payload, rawCallback) => {
       const callback = toAck(rawCallback);
+      if (!checkRateLimit(clientIp, 'control', RATE_LIMIT_MAX_CONTROL_EVENTS)) {
+        metrics.rateLimitHits.inc({ bucket: 'control' });
+        callback?.({ success: false, error: 'Control rate limit exceeded' });
+        return;
+      }
       const requested = isRecord(payload) ? payload.channelId : undefined;
       const channelId = typeof requested === 'string' && requested ? requested : currentChannelId;
 
@@ -438,6 +528,11 @@ export function createRelayServer(httpServer: HttpServer): RelayHandle {
      */
     socket.on('close_channel', (payload, rawCallback) => {
       const callback = toAck(rawCallback);
+      if (!checkRateLimit(clientIp, 'control', RATE_LIMIT_MAX_CONTROL_EVENTS)) {
+        metrics.rateLimitHits.inc({ bucket: 'control' });
+        callback?.({ success: false, error: 'Control rate limit exceeded' });
+        return;
+      }
       const requested = isRecord(payload) ? payload.channelId : undefined;
       const channelId = typeof requested === 'string' && requested ? requested : currentChannelId;
 
@@ -453,6 +548,7 @@ export function createRelayServer(httpServer: HttpServer): RelayHandle {
 
         if (participant) {
           channelManager.close(channelId);
+          refreshBufferMetrics();
 
           // Tell a currently-connected counterparty this was an explicit
           // close, distinct from a transient 'disconnect'.
@@ -475,6 +571,11 @@ export function createRelayServer(httpServer: HttpServer): RelayHandle {
      */
     socket.on('ping', (rawCallback) => {
       const callback = toAck(rawCallback);
+      if (!checkRateLimit(clientIp, 'control', RATE_LIMIT_MAX_CONTROL_EVENTS)) {
+        metrics.rateLimitHits.inc({ bucket: 'control' });
+        callback?.({ success: false, error: 'Control rate limit exceeded' });
+        return;
+      }
       callback?.({ type: 'pong', timestamp: Date.now() });
     });
 
@@ -484,6 +585,7 @@ export function createRelayServer(httpServer: HttpServer): RelayHandle {
     socket.on('disconnect', () => {
       metrics.activeSockets.dec();
       releaseSocketCounter();
+      releaseDirectDelivery(socket.id);
       if (currentChannelId) {
         const participant = channelManager.leave(socket.id, currentChannelId);
 
@@ -504,7 +606,13 @@ export function createRelayServer(httpServer: HttpServer): RelayHandle {
     clearInterval(rateLimitCleanupTimer);
     activeSocketsByIp.clear();
     rateLimits.clear();
+    for (const socketId of directDrainListeners.keys()) releaseDirectDelivery(socketId);
+    disconnectAfterDrain.clear();
     channelManager.destroy();
+    metrics.activeChannels.set(0);
+    metrics.bufferedMessages.set(0);
+    metrics.bufferedBytes.set(0);
+    metrics.directInflightBytes.set(0);
     io.removeAllListeners();
   };
 

--- a/src/routes/app.routes.ts
+++ b/src/routes/app.routes.ts
@@ -16,7 +16,9 @@ const txHistoryRateLimit = rateLimit({
 });
 
 const TX_HISTORY_MAX_LIMIT = 50;
+const TX_HISTORY_MAX_PAGE = 100_000;
 const TX_HISTORY_TIMEOUT_MS = 8000;
+const TX_HISTORY_MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
 
 const clampPositiveInt = (raw: unknown, fallback: number, max: number | null): number => {
   const n = Number(raw);
@@ -42,7 +44,7 @@ appRouter.post(
     // limit=100000 forces zondscan to return (and us to buffer) an enormous
     // response, and a no-timeout axios call below would block the worker for
     // the full TCP timeout (~2 min) if zondscan stalls.
-    const page = clampPositiveInt(isRecord(body) ? body.page : undefined, 1, null);
+    const page = clampPositiveInt(isRecord(body) ? body.page : undefined, 1, TX_HISTORY_MAX_PAGE);
     const limit = clampPositiveInt(
       isRecord(body) ? body.limit : undefined,
       5,
@@ -53,7 +55,15 @@ appRouter.post(
     try {
       const response = await axios.get<unknown>(
         `https://zondscan.com/api/address/${formattedAddress}/transactions`,
-        { params: { page, limit }, timeout: TX_HISTORY_TIMEOUT_MS }
+        {
+          params: { page, limit },
+          timeout: TX_HISTORY_TIMEOUT_MS,
+          maxContentLength: TX_HISTORY_MAX_RESPONSE_BYTES,
+          // Keep this fixed-origin proxy from following a compromised
+          // upstream redirect into loopback, metadata, or another private
+          // service.
+          maxRedirects: 0,
+        }
       );
       log.debug({ address: formattedAddress }, 'Tx history fetched');
       res.status(200).json(response.data);

--- a/src/routes/health.routes.ts
+++ b/src/routes/health.routes.ts
@@ -1,7 +1,15 @@
 import { Router } from 'express';
+import { CONFIG } from '../config/index.js';
 import { healthMonitor, type HealthSnapshot } from '../services/rpc/healthMonitor.js';
 
 const router = Router();
+
+// Process liveness is independent of external chain readiness. Container
+// supervisors use this endpoint so an RPC stall does not create restart loops
+// that erase relay state and health-monitor history.
+router.get('/live', (_req, res) => {
+  res.status(200).json({ status: 'alive' });
+});
 
 /**
  * Strip the `url` field from each endpoint entry. The internal healthMonitor
@@ -23,11 +31,11 @@ const redactSnapshot = (snapshot: HealthSnapshot) => {
 
 router.get('/', (_req, res) => {
   const endpoints = redactSnapshot(healthMonitor.getSnapshot());
-  const networks = Object.keys(endpoints);
-  const anyHealthy =
-    networks.length === 0 || networks.some((n) => healthMonitor.hasHealthyForNetwork(n));
-  const status = anyHealthy ? 'ok' : 'degraded';
-  const httpStatus = anyHealthy ? 200 : 503;
+  const allRequiredHealthy =
+    CONFIG.RPC_REQUIRED_NETWORKS.length > 0 &&
+    CONFIG.RPC_REQUIRED_NETWORKS.every((network) => healthMonitor.hasHealthyForNetwork(network));
+  const status = allRequiredHealthy ? 'ok' : 'degraded';
+  const httpStatus = allRequiredHealthy ? 200 : 503;
   res.status(httpStatus).json({ status, endpoints });
 });
 

--- a/src/routes/ipfs.routes.ts
+++ b/src/routes/ipfs.routes.ts
@@ -1,6 +1,6 @@
 import { Router, type Request, type Response } from 'express';
 import rateLimit from 'express-rate-limit';
-import { parsePositiveInt } from '../config/index.js';
+import { CONFIG } from '../config/index.js';
 import { asyncHandler } from '../utils/async-handler.js';
 import { isRecord } from '../utils/guards.js';
 import { logger } from '../utils/logger.js';
@@ -17,8 +17,66 @@ const log = logger.child({ module: 'ipfs-routes' });
  * which is widely available + Cloudflare-fronted.
  */
 const IPFS_GATEWAY = (process.env.IPFS_GATEWAY ?? 'https://ipfs.io/ipfs/').replace(/\/?$/, '/');
-const FETCH_TIMEOUT_MS = parsePositiveInt(process.env.IPFS_FETCH_TIMEOUT_MS, 8000);
-const MAX_SIZE = parsePositiveInt(process.env.IPFS_MAX_SIZE_BYTES, 10 * 1024 * 1024); // 10 MB
+
+let activeFetches = 0;
+let reservedInflightBytes = 0;
+
+function acquireFetchSlot(): (() => void) | null {
+  const reservation = CONFIG.IPFS_MAX_SIZE_BYTES;
+  if (
+    activeFetches >= CONFIG.IPFS_MAX_CONCURRENT ||
+    reservedInflightBytes + reservation > CONFIG.IPFS_MAX_INFLIGHT_BYTES
+  ) {
+    return null;
+  }
+
+  activeFetches += 1;
+  reservedInflightBytes += reservation;
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    activeFetches -= 1;
+    reservedInflightBytes -= reservation;
+  };
+}
+
+function sendStreamError(res: Response, status: number, error: string): void {
+  if (res.headersSent) {
+    res.destroy();
+    return;
+  }
+  res.status(status).json({ error });
+}
+
+function writeChunkWithAbort(res: Response, value: Uint8Array, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (error?: Error | null): void => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener('abort', onAbort);
+      if (error) reject(error);
+      else resolve();
+    };
+    const onAbort = (): void => {
+      const error = new Error('IPFS response deadline exceeded');
+      error.name = 'AbortError';
+      finish(error);
+    };
+
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    signal.addEventListener('abort', onAbort, { once: true });
+    try {
+      res.write(value, finish);
+    } catch (error) {
+      finish(error instanceof Error ? error : new Error(String(error)));
+    }
+  });
+}
 
 // CIDv0: starts with Qm + 44 base58 chars (no 0, O, I, l)
 const CIDV0_RE = /^Qm[1-9A-HJ-NP-Za-km-z]{44}$/;
@@ -82,15 +140,35 @@ async function ipfsHandler(req: Request, res: Response): Promise<void> {
     return;
   }
 
+  const releaseFetchSlot = acquireFetchSlot();
+  if (!releaseFetchSlot) {
+    res.set('Retry-After', '1').status(503).json({ error: 'IPFS proxy busy' });
+    return;
+  }
+
   const url = `${IPFS_GATEWAY}${cid}${rest ? '/' + rest : ''}`;
   const controller = new AbortController();
   const timeout = setTimeout(() => {
     controller.abort();
-  }, FETCH_TIMEOUT_MS);
+  }, CONFIG.IPFS_FETCH_TIMEOUT_MS);
+  let clientDisconnected = false;
+  const abortForDisconnect = (): void => {
+    clientDisconnected = true;
+    controller.abort();
+  };
+  const abortForEarlyClose = (): void => {
+    if (!res.writableEnded) abortForDisconnect();
+  };
+  req.once('aborted', abortForDisconnect);
+  res.once('close', abortForEarlyClose);
 
   try {
-    const response = await fetchImpl(url, { signal: controller.signal, redirect: 'follow' });
+    // Keep the request pinned to the configured gateway origin. Following an
+    // upstream redirect would turn a compromised gateway into an SSRF hop to
+    // loopback, cloud metadata, or another private service.
+    const response = await fetchImpl(url, { signal: controller.signal, redirect: 'error' });
     if (!response.ok) {
+      controller.abort();
       log.warn({ cid, status: response.status }, 'IPFS gateway returned non-2xx');
       res
         .status(response.status === 404 ? 404 : 502)
@@ -104,8 +182,11 @@ async function ipfsHandler(req: Request, res: Response): Promise<void> {
     // enforce the cap incrementally as we read the body; never let an
     // attacker buffer >MAX_SIZE into our heap.
     const declaredSize = parseInt(response.headers.get('content-length') ?? '0', 10);
-    if (declaredSize > MAX_SIZE) {
-      res.status(413).json({ error: 'too large', size: declaredSize, max: MAX_SIZE });
+    if (declaredSize > CONFIG.IPFS_MAX_SIZE_BYTES) {
+      controller.abort();
+      res
+        .status(413)
+        .json({ error: 'too large', size: declaredSize, max: CONFIG.IPFS_MAX_SIZE_BYTES });
       return;
     }
 
@@ -124,65 +205,90 @@ async function ipfsHandler(req: Request, res: Response): Promise<void> {
     // here and verify it at runtime (instanceof below) instead of trusting it.
     const stream: ReadableStream<unknown> = response.body;
     const reader = stream.getReader();
-    const chunks: Uint8Array[] = [];
     let received = 0;
+    let proxyHeadersSet = false;
+    const setProxyHeaders = (): void => {
+      if (proxyHeadersSet) return;
+      proxyHeadersSet = true;
+      res.set({
+        'Content-Type': contentType,
+        // IPFS content is content-addressed, so caching for an hour is safe.
+        'Cache-Control': 'public, max-age=3600, immutable',
+        // Sane defaults; never let user-supplied content advertise itself
+        // as the wallet's own scripts.
+        'X-Content-Type-Options': 'nosniff',
+        'Content-Security-Policy': "default-src 'none'; img-src 'self' data: blob:; sandbox",
+      });
+    };
     try {
       for (;;) {
         const { done, value } = await reader.read();
         if (done) break;
         if (!(value instanceof Uint8Array)) {
-          log.error({ url }, 'IPFS gateway stream yielded a non-binary chunk');
-          res.status(502).json({ error: 'gateway stream error' });
+          log.error({ cid, rest }, 'IPFS gateway stream yielded a non-binary chunk');
+          controller.abort();
+          void reader.cancel().catch(() => undefined);
+          sendStreamError(res, 502, 'gateway stream error');
           return;
         }
-        received += value.byteLength;
-        if (received > MAX_SIZE) {
-          // Stop pulling bytes off the gateway socket before we ever
-          // commit them to our heap. cancel() may reject if the stream
-          // is already closed; swallow that.
+        if (received + value.byteLength > CONFIG.IPFS_MAX_SIZE_BYTES) {
+          // Never write a byte beyond the cap. Once streaming has started an
+          // HTTP status cannot be changed, so terminate that partial response.
           try {
             await reader.cancel();
           } catch {
             /* noop */
           }
-          res.status(413).json({ error: 'too large', size: received, max: MAX_SIZE });
+          controller.abort();
+          if (!res.headersSent) {
+            res.status(413).json({
+              error: 'too large',
+              size: received + value.byteLength,
+              max: CONFIG.IPFS_MAX_SIZE_BYTES,
+            });
+          } else {
+            res.destroy();
+          }
           return;
         }
-        chunks.push(value);
+        received += value.byteLength;
+        setProxyHeaders();
+        await writeChunkWithAbort(res, value, controller.signal);
       }
     } catch (streamErr) {
       // An AbortError mid-stream is the FETCH_TIMEOUT_MS controller firing,
       // not a stream-specific failure. Re-throw so the outer catch maps it
       // to 504 like the pre-streaming code did. Anything else stays a 502.
       if (isRecord(streamErr) && streamErr.name === 'AbortError') throw streamErr;
-      log.error({ err: streamErr, url }, 'IPFS proxy stream read failed');
-      res.status(502).json({ error: 'gateway stream error' });
+      if (clientDisconnected) return;
+      controller.abort();
+      void reader.cancel().catch(() => undefined);
+      log.error(
+        { cid, rest, errorName: streamErr instanceof Error ? streamErr.name : typeof streamErr },
+        'IPFS proxy stream read failed'
+      );
+      sendStreamError(res, 502, 'gateway stream error');
       return;
     }
-    // Buffer.concat accepts Uint8Array chunks directly; the previous
-    // .map(Buffer.from) was wasted work in a hot path.
-    const buf = Buffer.concat(chunks);
-
-    res.set({
-      'Content-Type': contentType,
-      // IPFS content is content-addressed, so caching for an hour is safe.
-      'Cache-Control': 'public, max-age=3600, immutable',
-      // Sane defaults; never let user-supplied content advertise itself
-      // as the wallet's own scripts.
-      'X-Content-Type-Options': 'nosniff',
-      'Content-Security-Policy': "default-src 'none'; img-src 'self' data: blob:; sandbox",
-    });
-    res.send(buf);
+    setProxyHeaders();
+    res.end();
   } catch (err) {
+    if (clientDisconnected) return;
     if (isRecord(err) && err.name === 'AbortError') {
       log.warn({ cid, rest }, 'IPFS proxy timeout');
-      res.status(504).json({ error: 'gateway timeout' });
+      sendStreamError(res, 504, 'gateway timeout');
       return;
     }
-    log.error({ err: err instanceof Error ? err.message : err, url }, 'IPFS proxy failed');
-    res.status(502).json({ error: 'gateway unreachable' });
+    log.error(
+      { cid, rest, errorName: err instanceof Error ? err.name : typeof err },
+      'IPFS proxy failed'
+    );
+    sendStreamError(res, 502, 'gateway unreachable');
   } finally {
     clearTimeout(timeout);
+    req.off('aborted', abortForDisconnect);
+    res.off('close', abortForEarlyClose);
+    releaseFetchSlot();
   }
 }
 

--- a/src/routes/rpc.routes.ts
+++ b/src/routes/rpc.routes.ts
@@ -1,13 +1,12 @@
 import { Router } from 'express';
+import { CONFIG } from '../config/index.js';
 import { normalizeRpcId, rpcService } from '../services/rpc.service.js';
 import { asyncHandler } from '../utils/async-handler.js';
 import { isRecord } from '../utils/guards.js';
 import {
   rpcBatchReject,
   rpcMethodWhitelist,
-  rpcRateLimitGeneral,
   rpcRateLimitWrite,
-  rpcRequestSizeLimit,
   rpcParamsValidator,
   rpcSecurityLogger,
   getAllowedMethods,
@@ -35,29 +34,24 @@ router.get('/:network', (req, res) => {
     },
     allowed_methods: methods,
     rate_limits: {
-      read: '1000 requests/min per IP',
-      write: '10 requests/min per IP (sendRawTransaction, sendTransaction)',
+      admission: `${CONFIG.RPC_RATE_LIMIT_PER_MINUTE} requests/min per IP for all RPC traffic`,
+      write: `${CONFIG.RPC_WRITE_RATE_LIMIT_PER_MINUTE} requests/min per IP (sendRawTransaction)`,
     },
     max_payload: '50KB',
   });
 });
 
 // Apply security middleware in order:
-// 1. Request size limit (reject oversized payloads early)
-// 2. Batch reject (block batch requests)
-// 3. Security logger (log all requests)
-// 4. Method whitelist (block disallowed methods)
-// 5. Params validator (validate input)
-// 6. Rate limiters (apply appropriate limits)
+// The application-level admission limiter runs before JSON parsing. The
+// application JSON parser then enforces the actual 50KB decoded-body limit.
+// Valid write methods pass through an additional stricter limiter here.
 router.post(
   '/:network',
-  rpcRequestSizeLimit,
-  rpcBatchReject,
   rpcSecurityLogger,
+  rpcBatchReject,
   rpcMethodWhitelist,
-  rpcParamsValidator,
-  rpcRateLimitGeneral,
   rpcRateLimitWrite,
+  rpcParamsValidator,
   asyncHandler(async (req, res) => {
     const network = req.params.network ?? '';
     const body: unknown = req.body;

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,13 @@ import { CONFIG } from './config/index.js';
 import { createRelayServer } from './relay/relayServer.js';
 import { timingSafeEqualStrings } from './crypto/primitives.js';
 import { logger } from './utils/logger.js';
-import { activeChannels, bufferedMessages, register } from './relay/metrics.js';
+import {
+  activeChannels,
+  bufferedBytes,
+  bufferedMessages,
+  directInflightBytes,
+  register,
+} from './relay/metrics.js';
 import { healthMonitor } from './services/rpc/healthMonitor.js';
 
 const httpServer = createServer(app);
@@ -41,6 +47,8 @@ function refreshRelayGauges(): void {
   const stats = relay.channelManager.getStats();
   activeChannels.set(relay.channelManager.getActiveChannelCount());
   bufferedMessages.set(stats.totalBufferedMessages);
+  bufferedBytes.set(stats.totalBufferedBytes);
+  directInflightBytes.set(stats.totalDirectInflightBytes);
 }
 
 // Relay stats health endpoint
@@ -81,8 +89,8 @@ process.on('SIGTERM', () => {
   shutdown('SIGTERM');
 });
 
-httpServer.listen(CONFIG.PORT, () => {
-  logger.info({ port: CONFIG.PORT }, 'Server started');
+httpServer.listen(CONFIG.PORT, CONFIG.LISTEN_HOST, () => {
+  logger.info({ host: CONFIG.LISTEN_HOST, port: CONFIG.PORT }, 'Server started');
   logger.info('Socket.IO relay available at /relay');
   healthMonitor.start();
 });

--- a/src/services/notifier.ts
+++ b/src/services/notifier.ts
@@ -17,6 +17,16 @@ const SEVERITY_TO_PINO: Record<NotifySeverity, 'info' | 'warn' | 'error'> = {
   critical: 'error',
 };
 
+export function redactEndpointForLogs(endpoint: string | undefined): string | undefined {
+  if (endpoint === undefined) return undefined;
+  try {
+    const parsed = new URL(endpoint);
+    return parsed.origin === 'null' ? '[redacted RPC endpoint]' : parsed.origin;
+  } catch {
+    return '[invalid RPC endpoint]';
+  }
+}
+
 /**
  * Single point through which the backend reports operational health events
  * (e.g. RPC endpoint flipping up/down/stalled). Today this is just a structured
@@ -29,15 +39,16 @@ const SEVERITY_TO_PINO: Record<NotifySeverity, 'info' | 'warn' | 'error'> = {
  */
 export function notify({ severity = 'info', network, endpoint, event, detail }: HealthEvent): void {
   const level = SEVERITY_TO_PINO[severity];
+  const safeEndpoint = redactEndpointForLogs(endpoint);
   logger[level](
     {
       kind: 'rpc-health',
       severity,
       network,
-      endpoint,
+      endpoint: safeEndpoint,
       event,
       detail,
     },
-    `[rpc-health] ${event} ${endpoint ?? ''} (${network ?? 'n/a'})`.trim()
+    `[rpc-health] ${event} ${safeEndpoint ?? ''} (${network ?? 'n/a'})`.trim()
   );
 }

--- a/src/services/rpc.service.ts
+++ b/src/services/rpc.service.ts
@@ -1,6 +1,7 @@
 import { CONFIG, isNetworkName } from '../config/index.js';
 import { cache } from '../utils/cache.js';
-import { isRecord, toError } from '../utils/guards.js';
+import { HttpError, isRecord, toError } from '../utils/guards.js';
+import { BoundedJsonError, readBoundedJsonResponse } from '../utils/bounded-json.js';
 import { healthMonitor } from './rpc/healthMonitor.js';
 
 /**
@@ -42,6 +43,58 @@ export function normalizeRpcId(raw: unknown): RpcId {
   return null;
 }
 
+let activeRpcCalls = 0;
+let reservedRpcResponseBytes = 0;
+
+/**
+ * Reserve the full per-response allowance before starting an upstream call.
+ * This keeps worst-case concurrent response buffering within a deterministic
+ * process-wide budget even when every upstream omits Content-Length.
+ */
+function acquireRpcCallSlot(): (() => void) | null {
+  const reservation = CONFIG.RPC_MAX_RESPONSE_BYTES;
+  if (
+    activeRpcCalls >= CONFIG.RPC_MAX_CONCURRENT ||
+    reservedRpcResponseBytes + reservation > CONFIG.RPC_MAX_INFLIGHT_BYTES
+  ) {
+    return null;
+  }
+
+  activeRpcCalls += 1;
+  reservedRpcResponseBytes += reservation;
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    activeRpcCalls -= 1;
+    reservedRpcResponseBytes -= reservation;
+  };
+}
+
+async function readBoundedRpcJson(
+  response: Response,
+  controller: AbortController
+): Promise<unknown> {
+  try {
+    return await readBoundedJsonResponse(response, controller, CONFIG.RPC_MAX_RESPONSE_BYTES);
+  } catch (error) {
+    if (!(error instanceof BoundedJsonError)) throw error;
+    if (error.failure === 'too-large') {
+      throw new HttpError(502, 'RPC upstream response too large');
+    }
+    if (error.failure === 'empty') {
+      throw new HttpError(502, 'RPC upstream returned an empty response body');
+    }
+    if (error.failure === 'non-binary') {
+      throw new HttpError(502, 'RPC upstream returned a non-binary response chunk');
+    }
+    if (error.failure === 'invalid-json') {
+      throw new HttpError(502, 'RPC upstream returned invalid JSON');
+    }
+    throw new HttpError(502, 'RPC upstream returned an invalid response body');
+  }
+}
+
 class RPCService {
   async makeRPCCall(
     endpoint: string,
@@ -49,6 +102,11 @@ class RPCService {
     params: unknown,
     id: RpcId = null
   ): Promise<unknown> {
+    const releaseRpcCallSlot = acquireRpcCallSlot();
+    if (!releaseRpcCallSlot) {
+      throw new HttpError(503, 'RPC proxy busy');
+    }
+
     const controller = new AbortController();
     const timer = setTimeout(() => {
       controller.abort();
@@ -70,15 +128,24 @@ class RPCService {
           params,
         }),
         signal: controller.signal,
+        redirect: 'error',
       });
 
       if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
+        controller.abort();
+        throw new HttpError(502, `RPC upstream HTTP ${response.status}`);
       }
 
-      return await response.json();
+      return await readBoundedRpcJson(response, controller);
+    } catch (err) {
+      if (err instanceof HttpError) throw err;
+      if (isRecord(err) && err.name === 'AbortError') {
+        throw new HttpError(502, 'RPC upstream timeout');
+      }
+      throw new HttpError(502, 'RPC upstream unavailable');
     } finally {
       clearTimeout(timer);
+      releaseRpcCallSlot();
     }
   }
 
@@ -127,10 +194,11 @@ class RPCService {
       try {
         result = await this.makeRPCCall(url, method, params, id);
         chosenUrl = url;
-        healthMonitor.recordRequestResult(network, url, true);
         break;
       } catch (err) {
-        healthMonitor.recordRequestResult(network, url, false, err);
+        // Admission is process-wide, so retrying another endpoint cannot help
+        // and would only add work while the proxy is saturated.
+        if (err instanceof HttpError && err.status === 503) throw err;
         lastError = toError(err);
       }
     }

--- a/src/services/rpc/healthMonitor.ts
+++ b/src/services/rpc/healthMonitor.ts
@@ -1,6 +1,7 @@
 import { CONFIG } from '../../config/index.js';
 import { logger } from '../../utils/logger.js';
 import { isRecord, toError } from '../../utils/guards.js';
+import { BoundedJsonError, readBoundedJsonResponse } from '../../utils/bounded-json.js';
 import { notify } from '../notifier.js';
 
 export type EndpointState = 'up' | 'down' | 'stalled' | 'unknown';
@@ -9,6 +10,7 @@ const STATE_UP: EndpointState = 'up';
 const STATE_DOWN: EndpointState = 'down';
 const STATE_STALLED: EndpointState = 'stalled';
 const STATE_UNKNOWN: EndpointState = 'unknown';
+const HEALTH_RESPONSE_MAX_BYTES = 16 * 1024;
 
 const STATE_ORDER: Record<EndpointState, number> = {
   [STATE_UP]: 0,
@@ -61,6 +63,16 @@ function parseHexHeight(hex: unknown): number | null {
   if (typeof hex !== 'string' || !hex.startsWith('0x')) return null;
   const n = Number.parseInt(hex.slice(2), 16);
   return Number.isFinite(n) ? n : null;
+}
+
+/** Convert untrusted fetch failures into stable, credential-free categories. */
+function sanitizeHealthError(error: unknown): Error {
+  const err = toError(error);
+  if (err instanceof BoundedJsonError) return new Error(err.message);
+  if (err.name === 'AbortError') return new Error('upstream request timed out');
+  if (/^HTTP \d{3}$/.test(err.message)) return new Error(err.message);
+  if (err.message === 'Unparseable qrl_blockNumber result') return new Error(err.message);
+  return new Error('upstream health check failed');
 }
 
 class HealthMonitor {
@@ -149,23 +161,9 @@ class HealthMonitor {
     this.init();
     const endpoints = this.networks.get(network);
     if (!endpoints) return false;
-    // Stalled endpoints still route requests (with stale data), so /health
-    // mirrors that: 503 only when every endpoint is fully `down`. The
-    // per-endpoint `state` in the response surfaces stalled vs up.
-    return endpoints.some((e) => e.state !== STATE_DOWN);
-  }
-
-  recordRequestResult(network: string, url: string, ok: boolean, error?: unknown): void {
-    this.init();
-    const endpoints = this.networks.get(network);
-    if (!endpoints) return;
-    const ep = endpoints.find((e) => e.url === url);
-    if (!ep) return;
-    if (ok) {
-      this.applyRequestSuccess(network, ep);
-    } else {
-      this.applyFailure(network, ep, error);
-    }
+    // Only a confirmed-up endpoint makes the network ready. Unknown startup
+    // state, stalled chain height and transport failure all fail readiness.
+    return endpoints.some((e) => e.state === STATE_UP);
   }
 
   getSnapshot(): HealthSnapshot {
@@ -215,14 +213,19 @@ class HealthMonitor {
           params: [],
         }),
         signal: controller.signal,
+        redirect: 'error',
       });
       ep.lastPollAt = Date.now();
       ep.lastLatencyMs = Date.now() - start;
       if (!response.ok) {
+        controller.abort();
         this.applyFailure(network, ep, new Error(`HTTP ${response.status}`));
         return;
       }
-      const json: unknown = await response.json();
+      // qrl_blockNumber is a tiny envelope. Bound even this operator poll so
+      // a compromised or misconfigured upstream cannot stream the process out
+      // of memory outside the client-facing RPC admission controls.
+      const json = await readBoundedJsonResponse(response, controller, HEALTH_RESPONSE_MAX_BYTES);
       const height = parseHexHeight(isRecord(json) ? json.result : undefined);
       if (height === null) {
         this.applyFailure(network, ep, new Error('Unparseable qrl_blockNumber result'));
@@ -314,38 +317,9 @@ class HealthMonitor {
     }
   }
 
-  applyRequestSuccess(network: string, ep: EndpointRecord): void {
-    ep.consecutiveFailures = 0;
-    ep.consecutiveSuccesses += 1;
-    ep.lastError = null;
-    const previousState = ep.state;
-    let newState = previousState;
-    if (
-      previousState === STATE_DOWN &&
-      ep.consecutiveSuccesses >= CONFIG.RPC_HEALTH.UP_AFTER_SUCCESSES
-    ) {
-      newState = STATE_UP;
-    } else if (previousState === STATE_UNKNOWN) {
-      // A real request succeeded: flip out of unknown immediately rather
-      // than waiting for the next background poll. Otherwise the selector
-      // keeps ranking this endpoint behind any sibling already at `up`.
-      newState = STATE_UP;
-    }
-    if (newState !== previousState) {
-      ep.state = newState;
-      notify({
-        severity: 'info',
-        network,
-        endpoint: ep.url,
-        event: 'up',
-        detail: { source: 'request', previousState },
-      });
-    }
-  }
-
   applyFailure(network: string, ep: EndpointRecord, error: unknown): void {
     const previousState = ep.state;
-    const err = toError(error);
+    const err = sanitizeHealthError(error);
     ep.consecutiveFailures += 1;
     ep.consecutiveSuccesses = 0;
     ep.lastError = err;

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,6 +1,6 @@
 /**
  * Express request augmentation. `rpcMethodType` is stamped by the
- * rpcMethodWhitelist middleware and consumed by the tiered rate limiters.
+ * rpcMethodWhitelist middleware and consumed by the write rate limiter.
  */
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/src/utils/bounded-json.ts
+++ b/src/utils/bounded-json.ts
@@ -1,0 +1,100 @@
+export type BoundedJsonFailure =
+  | 'too-large'
+  | 'empty'
+  | 'non-binary'
+  | 'invalid-utf8'
+  | 'invalid-json'
+  | 'stream-error';
+
+export class BoundedJsonError extends Error {
+  constructor(
+    readonly failure: BoundedJsonFailure,
+    message: string,
+    options?: ErrorOptions
+  ) {
+    super(message, options);
+    this.name = 'BoundedJsonError';
+  }
+}
+
+function declaredBodyIsOversize(value: string | null, maxBytes: number): boolean {
+  if (value === null || !/^\d+$/.test(value)) return false;
+  return BigInt(value) > BigInt(maxBytes);
+}
+
+/**
+ * Incrementally read and decode an untrusted fetch response under a hard byte
+ * cap. Any failure before EOF aborts and cancels the body so an upstream cannot
+ * continue streaming after the caller has already rejected its response.
+ */
+export async function readBoundedJsonResponse(
+  response: Response,
+  controller: AbortController,
+  maxBytes: number
+): Promise<unknown> {
+  if (declaredBodyIsOversize(response.headers.get('content-length'), maxBytes)) {
+    controller.abort();
+    throw new BoundedJsonError('too-large', 'response body too large');
+  }
+  if (!response.body) {
+    throw new BoundedJsonError('empty', 'response body is empty');
+  }
+
+  const stream: ReadableStream<unknown> = response.body;
+  const reader = stream.getReader();
+  const decoder = new TextDecoder('utf-8', { fatal: true });
+  let received = 0;
+  let body = '';
+  let reachedEof = false;
+
+  try {
+    for (;;) {
+      let chunk;
+      try {
+        chunk = await reader.read();
+      } catch (error) {
+        throw new BoundedJsonError('stream-error', 'response stream failed', { cause: error });
+      }
+      if (chunk.done) break;
+      if (!(chunk.value instanceof Uint8Array)) {
+        throw new BoundedJsonError('non-binary', 'response stream yielded a non-binary chunk');
+      }
+      if (received + chunk.value.byteLength > maxBytes) {
+        throw new BoundedJsonError('too-large', 'response body too large');
+      }
+      received += chunk.value.byteLength;
+      try {
+        body += decoder.decode(chunk.value, { stream: true });
+      } catch (error) {
+        throw new BoundedJsonError('invalid-utf8', 'response body is not valid UTF-8', {
+          cause: error,
+        });
+      }
+    }
+
+    try {
+      body += decoder.decode();
+    } catch (error) {
+      throw new BoundedJsonError('invalid-utf8', 'response body is not valid UTF-8', {
+        cause: error,
+      });
+    }
+    reachedEof = true;
+  } finally {
+    if (!reachedEof) {
+      controller.abort();
+      void reader.cancel().catch(() => undefined);
+    }
+  }
+
+  if (received === 0) {
+    throw new BoundedJsonError('empty', 'response body is empty');
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(body);
+    return parsed;
+  } catch (error) {
+    throw new BoundedJsonError('invalid-json', 'response body is not valid JSON', { cause: error });
+  }
+}

--- a/src/utils/client-ip.ts
+++ b/src/utils/client-ip.ts
@@ -1,0 +1,48 @@
+import type { IncomingMessage } from 'node:http';
+import { ipKeyGenerator } from 'express-rate-limit';
+import proxyaddr from 'proxy-addr';
+import { CONFIG } from '../config/index.js';
+
+type TrustProxy = (address: string, index: number) => boolean;
+
+let cachedCidrs = '';
+let cachedTrust: TrustProxy = () => false;
+
+function getTrustProxy(): TrustProxy {
+  const cidrs = CONFIG.TRUSTED_PROXY_CIDRS.join(',');
+  if (cidrs === cachedCidrs) return cachedTrust;
+
+  cachedCidrs = cidrs;
+  cachedTrust = CONFIG.TRUSTED_PROXY_CIDRS.length
+    ? proxyaddr.compile(CONFIG.TRUSTED_PROXY_CIDRS)
+    : () => false;
+  return cachedTrust;
+}
+
+/** Express trust-proxy callback. Forwarded hops are trusted only by CIDR. */
+export function isTrustedProxy(address: string, index: number): boolean {
+  return getTrustProxy()(address, index);
+}
+
+/**
+ * Resolve a request's closest untrusted address, walking X-Forwarded-For from
+ * right to left. Vendor headers are intentionally ignored: an origin request
+ * can forge them unless the edge strips and rewrites them first.
+ */
+export function getTrustedClientIp(request: IncomingMessage): string {
+  try {
+    return proxyaddr(request, getTrustProxy());
+  } catch {
+    return request.socket.remoteAddress ?? 'unknown';
+  }
+}
+
+/**
+ * Collapse IPv6 privacy addresses to a stable prefix before applying any
+ * per-client admission or memory budget. Exact IPv6 addresses are cheap to
+ * rotate within one delegated prefix and would make those controls trivial
+ * to bypass. IPv4 addresses and malformed fallback values pass through.
+ */
+export function normalizeClientIpForLimits(ip: string): string {
+  return ipKeyGenerator(ip);
+}

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,0 +1,26 @@
+import * as chai from 'chai';
+import { resolveListenHost } from '../src/config/index.js';
+import { normalizeClientIpForLimits } from '../src/utils/client-ip.js';
+
+const { expect } = chai;
+
+describe('server configuration', () => {
+  it('binds to loopback by default', () => {
+    expect(resolveListenHost(undefined)).to.equal('127.0.0.1');
+    expect(resolveListenHost('  ')).to.equal('127.0.0.1');
+  });
+
+  it('allows an explicit container bind address', () => {
+    expect(resolveListenHost('0.0.0.0')).to.equal('0.0.0.0');
+  });
+
+  it('groups IPv6 privacy addresses by delegated prefix for admission limits', () => {
+    const first = normalizeClientIpForLimits('2001:db8:1234:5601::1');
+    const rotated = normalizeClientIpForLimits('2001:db8:1234:56ff::2');
+    const otherPrefix = normalizeClientIpForLimits('2001:db8:1234:5701::1');
+
+    expect(first).to.equal(rotated);
+    expect(first).not.to.equal(otherPrefix);
+    expect(normalizeClientIpForLimits('198.51.100.7')).to.equal('198.51.100.7');
+  });
+});

--- a/test/middleware/error-handler.test.js
+++ b/test/middleware/error-handler.test.js
@@ -1,0 +1,66 @@
+import * as chai from 'chai';
+import sinon from 'sinon';
+
+const { expect } = chai;
+
+import { errorHandler } from '../../src/middleware/error-handler.js';
+import { logger } from '../../src/utils/logger.js';
+
+describe('errorHandler', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('does not copy body-parser raw request data into logs', () => {
+    const logStub = sinon.stub(logger, 'warn');
+    const error = Object.assign(new SyntaxError('Malformed JSON'), {
+      status: 400,
+      body: '{"signedTransaction":"sensitive-wallet-data"',
+    });
+    const response = {
+      headersSent: false,
+      status: sinon.stub().returnsThis(),
+      json: sinon.stub(),
+    };
+
+    errorHandler(error, {}, response, sinon.stub());
+
+    expect(response.status.calledWith(400)).to.equal(true);
+    expect(logStub.calledOnce).to.equal(true);
+    expect(JSON.stringify(logStub.firstCall.args[0])).not.to.include('sensitive-wallet-data');
+  });
+
+  it('redacts JSON parser messages that embed request fragments', () => {
+    const logStub = sinon.stub(logger, 'warn');
+    const error = Object.assign(
+      new SyntaxError('Unexpected token n in JSON at position 0 near notsecretseedmaterial'),
+      {
+        status: 400,
+        type: 'entity.parse.failed',
+        body: 'notsecretseedmaterial',
+      }
+    );
+    const response = {
+      headersSent: false,
+      status: sinon.stub().returnsThis(),
+      json: sinon.stub(),
+    };
+
+    errorHandler(error, {}, response, sinon.stub());
+
+    const logged = JSON.stringify(logStub.firstCall.args[0]);
+    const returned = JSON.stringify(response.json.firstCall.args[0]);
+    expect(logged).not.to.include('notsecretseedmaterial');
+    expect(returned).not.to.include('notsecretseedmaterial');
+    expect(response.json.firstCall.args[0].error.message).to.equal('Invalid request body');
+  });
+
+  it('delegates errors after response headers have been sent', () => {
+    const error = new Error('late stream failure');
+    const next = sinon.stub();
+
+    errorHandler(error, {}, { headersSent: true }, next);
+
+    expect(next.calledOnceWithExactly(error)).to.equal(true);
+  });
+});

--- a/test/relay/relay.test.js
+++ b/test/relay/relay.test.js
@@ -28,13 +28,14 @@ function startRelay(configOverrides = {}) {
   }
 
   const httpServer = createServer();
-  const { io, destroy } = createRelayServer(httpServer);
+  const { io, channelManager, destroy } = createRelayServer(httpServer);
 
   return new Promise((resolve) => {
     httpServer.listen(0, () => {
       const port = httpServer.address().port;
       resolve({
         io,
+        channelManager,
         httpServer,
         port,
         cleanup: () => {
@@ -241,6 +242,17 @@ describe('Relay Server', function () {
 
     // ── v2 PK-binding semantics ─────────────────────────────────────────
 
+    it('should pin a joined socket to its original clientType', async () => {
+      const socket = await connect(relay.port);
+      expect((await joinChannel(socket, 'ch-role-pin', 'dapp')).success).to.equal(true);
+
+      const switched = await joinChannel(socket, 'ch-role-pin', 'wallet');
+
+      expect(switched.success).to.equal(false);
+      expect(switched.error).to.include('cannot change clientType');
+      await disconnect(socket);
+    });
+
     it('should bind a dapp public key to the channel on first join', async () => {
       const dapp = await connect(relay.port);
       const resp = await joinChannel(dapp, 'ch-pk-bind', 'dapp', TEST_DAPP_PK);
@@ -358,6 +370,45 @@ describe('Relay Server', function () {
 
       await disconnect(replacement);
       for (const s of sockets) await disconnect(s);
+    });
+  });
+
+  describe('trusted proxy attribution', () => {
+    it('ignores spoofed vendor IP headers from a direct peer', async () => {
+      const relay = await startRelay({
+        RELAY_MAX_SOCKETS_PER_IP: 2,
+        TRUSTED_PROXY_CIDRS: [],
+      });
+      const sockets = [];
+      try {
+        for (let i = 0; i < 2; i++) {
+          sockets.push(
+            await connect(relay.port, {
+              extraHeaders: { 'CF-Connecting-IP': `198.51.100.${i + 1}` },
+            })
+          );
+        }
+
+        let extra = null;
+        try {
+          extra = await connect(relay.port, {
+            extraHeaders: { 'CF-Connecting-IP': '198.51.100.200' },
+          });
+        } catch {
+          // A connection-level rejection is also a successful cap outcome.
+        }
+        if (extra) {
+          await new Promise((resolve) => {
+            extra.on('disconnect', resolve);
+            setTimeout(resolve, 500);
+          });
+          expect(extra.connected).to.be.false;
+          extra.close();
+        }
+      } finally {
+        for (const socket of sockets) await disconnect(socket);
+        relay.cleanup();
+      }
     });
   });
 
@@ -523,6 +574,94 @@ describe('Relay Server', function () {
     });
   });
 
+  describe('atomic channel switching', () => {
+    let relay;
+
+    before(async () => {
+      relay = await startRelay();
+    });
+    after(() => relay.cleanup());
+
+    it('preserves the old channel when the new channel has a role conflict', async () => {
+      const switchingDapp = await connect(relay.port);
+      const oldWallet = await connect(relay.port);
+      const conflictingDapp = await connect(relay.port);
+      await joinChannel(switchingDapp, 'switch-old-conflict', 'dapp');
+      await joinChannel(oldWallet, 'switch-old-conflict', 'wallet');
+      await joinChannel(conflictingDapp, 'switch-new-conflict', 'dapp');
+
+      const notices = [];
+      oldWallet.on('participants_changed', (notice) => notices.push(notice));
+      const conflict = await joinChannel(switchingDapp, 'switch-new-conflict', 'dapp');
+      expect(conflict.success).to.equal(false);
+      expect(conflict.error).to.include('already connected');
+
+      const received = waitForEvent(oldWallet, 'message');
+      const routed = await sendMessage(
+        switchingDapp,
+        'switch-old-conflict',
+        'old-channel-still-live'
+      );
+      expect(routed.success).to.equal(true);
+      expect((await received).message).to.equal('old-channel-still-live');
+      expect(notices).to.deep.equal([]);
+
+      const disconnected = waitForEvent(oldWallet, 'participants_changed');
+      await disconnect(switchingDapp);
+      expect((await disconnected).event).to.equal('disconnect');
+      await disconnect(oldWallet);
+      await disconnect(conflictingDapp);
+    });
+
+    it('preserves the old channel when the requested channel is tombstoned', async () => {
+      const switchingDapp = await connect(relay.port);
+      const oldWallet = await connect(relay.port);
+      const closer = await connect(relay.port);
+      await joinChannel(switchingDapp, 'switch-old-tombstone', 'dapp');
+      await joinChannel(oldWallet, 'switch-old-tombstone', 'wallet');
+      await joinChannel(closer, 'switch-dead', 'dapp');
+      await new Promise((resolve) => {
+        closer.emit('close_channel', { channelId: 'switch-dead' }, resolve);
+      });
+
+      const tombstone = await joinChannel(switchingDapp, 'switch-dead', 'dapp');
+      expect(tombstone.success).to.equal(true);
+      expect(tombstone.terminated).to.equal(true);
+
+      const received = waitForEvent(oldWallet, 'message');
+      const routed = await sendMessage(
+        switchingDapp,
+        'switch-old-tombstone',
+        'old-channel-survived'
+      );
+      expect(routed.success).to.equal(true);
+      expect((await received).message).to.equal('old-channel-survived');
+
+      await disconnect(switchingDapp);
+      await disconnect(oldWallet);
+      await disconnect(closer);
+    });
+
+    it('emits one leave event after a successful channel switch', async () => {
+      const dapp = await connect(relay.port);
+      const oldWallet = await connect(relay.port);
+      await joinChannel(dapp, 'switch-old-success', 'dapp');
+      await joinChannel(oldWallet, 'switch-old-success', 'wallet');
+
+      const notice = waitForEvent(oldWallet, 'participants_changed');
+      const switched = await joinChannel(dapp, 'switch-new-success', 'dapp');
+
+      expect(switched.success).to.equal(true);
+      expect(await notice).to.deep.equal({ event: 'leave', clientType: 'dapp' });
+      expect((await sendMessage(dapp, 'switch-old-success', 'must-not-route')).error).to.equal(
+        'Sender not in channel'
+      );
+
+      await disconnect(dapp);
+      await disconnect(oldWallet);
+    });
+  });
+
   // ── Leave channel ────────────────────────────────────────────────────
 
   describe('leave channel', () => {
@@ -597,6 +736,17 @@ describe('Relay Server', function () {
       expect(overLimit.error).to.include('Rate limit');
 
       await disconnect(dapp);
+    });
+
+    it('rate limits custom control events', async () => {
+      const socket = await connect(relay.port);
+      let response;
+      for (let i = 0; i < 301; i++) {
+        response = await new Promise((resolve) => socket.emit('ping', resolve));
+      }
+      expect(response.success).to.equal(false);
+      expect(response.error).to.include('Control rate limit');
+      await disconnect(socket);
     });
   });
 
@@ -691,6 +841,140 @@ describe('Relay Server', function () {
       });
       expect(resp.type).to.equal('pong');
       await disconnect(s);
+    });
+  });
+
+  describe('message canonicalization', () => {
+    it('drops unrecognized payload fields before forwarding', async () => {
+      const relay = await startRelay();
+      const dapp = await connect(relay.port);
+      const wallet = await connect(relay.port);
+      try {
+        await joinChannel(dapp, 'canonical-msg', 'dapp');
+        await joinChannel(wallet, 'canonical-msg', 'wallet');
+
+        const receivedPromise = waitForEvent(wallet, 'message');
+        const ackPromise = new Promise((resolve) => {
+          dapp.emit(
+            'message',
+            {
+              id: 'canonical-msg',
+              clientType: 'dapp',
+              message: 'ciphertext',
+              seq: 7,
+              attackerPadding: 'x'.repeat(100_000),
+            },
+            resolve
+          );
+        });
+
+        expect((await ackPromise).success).to.be.true;
+        expect(await receivedPromise).to.deep.equal({
+          id: 'canonical-msg',
+          clientType: 'dapp',
+          message: 'ciphertext',
+          seq: 7,
+        });
+      } finally {
+        await disconnect(dapp);
+        await disconnect(wallet);
+        relay.cleanup();
+      }
+    });
+  });
+
+  describe('live egress budgets', () => {
+    it('bounds a stalled target and drains buffered work through reconnect', async () => {
+      const relay = await startRelay({
+        RELAY_MAX_BUFFERED_BYTES_PER_CHANNEL: 1800,
+        RELAY_MAX_BUFFERED_BYTES_PER_IP: 1800,
+        RELAY_MAX_BUFFERED_BYTES_GLOBAL: 1800,
+      });
+      const dapp = await connect(relay.port);
+      const wallet = await connect(relay.port);
+      let replacement;
+      try {
+        await joinChannel(dapp, 'live-egress-budget', 'dapp');
+        await joinChannel(wallet, 'live-egress-budget', 'wallet');
+        await new Promise((resolve) => setImmediate(resolve));
+
+        const target = relay.io.sockets.sockets.get(wallet.id);
+        const transport = target.conn.transport;
+        const originalSend = transport.send;
+        transport.send = function () {
+          this.writable = false;
+        };
+        transport.writable = true;
+
+        const payload = 'x'.repeat(700);
+        const first = await sendMessage(dapp, 'live-egress-budget', payload);
+        expect(first).to.deep.include({ success: true, buffered: false });
+
+        const second = await sendMessage(dapp, 'live-egress-budget', `${payload}2`);
+        expect(second).to.deep.include({ success: true, buffered: true });
+
+        const rejected = await sendMessage(dapp, 'live-egress-budget', `${payload}3`);
+        expect(rejected.success).to.equal(false);
+        expect(rejected.error).to.include('capacity exceeded');
+
+        const stats = relay.channelManager.getStats();
+        expect(stats.totalDirectInflightBytes).to.be.greaterThan(0);
+        expect(stats.totalBufferedMessages).to.equal(1);
+        expect(stats.totalDirectInflightBytes + stats.totalBufferedBytes).to.be.at.most(1800);
+        expect(target.conn.writeBuffer.length).to.equal(0);
+
+        const disconnected = waitForEvent(wallet, 'disconnect');
+        transport.send = originalSend;
+        transport.emit('drain');
+        transport.writable = true;
+        transport.emit('ready');
+        await disconnected;
+        expect(relay.channelManager.getStats().totalDirectInflightBytes).to.equal(0);
+
+        replacement = await connect(relay.port);
+        const rejoined = await joinChannel(replacement, 'live-egress-budget', 'wallet');
+        expect(rejoined.success).to.equal(true);
+        expect(rejoined.bufferedMessages).to.have.length(1);
+        expect(rejoined.bufferedMessages[0].message).to.equal(`${payload}2`);
+      } finally {
+        await disconnect(dapp);
+        await disconnect(wallet);
+        if (replacement) await disconnect(replacement);
+        relay.cleanup();
+      }
+    });
+
+    it('does not traverse every channel after each routed message', async () => {
+      const relay = await startRelay();
+      const dapp = await connect(relay.port);
+      const wallet = await connect(relay.port);
+      try {
+        await joinChannel(dapp, 'metrics-cost', 'dapp');
+        await joinChannel(wallet, 'metrics-cost', 'wallet');
+
+        const originalGetStats = relay.channelManager.getStats.bind(relay.channelManager);
+        const originalGetActive = relay.channelManager.getActiveChannelCount.bind(
+          relay.channelManager
+        );
+        let traversals = 0;
+        relay.channelManager.getStats = () => {
+          traversals += 1;
+          return originalGetStats();
+        };
+        relay.channelManager.getActiveChannelCount = () => {
+          traversals += 1;
+          return originalGetActive();
+        };
+
+        const received = waitForEvent(wallet, 'message');
+        expect((await sendMessage(dapp, 'metrics-cost', 'ciphertext')).success).to.equal(true);
+        await received;
+        expect(traversals).to.equal(0);
+      } finally {
+        await disconnect(dapp);
+        await disconnect(wallet);
+        relay.cleanup();
+      }
     });
   });
 
@@ -810,6 +1094,17 @@ describe('Relay Server', function () {
   // ── ChannelManager unit: tombstone memory hygiene ────────────────────
 
   describe('ChannelManager tombstones', () => {
+    it('does not allocate a channel for an invalid public key', () => {
+      const cm = new ChannelManager();
+      try {
+        const result = cm.join('invalid-key-no-allocation', 'sock-a', 'dapp', 'not base64!');
+        expect(result.success).to.equal(false);
+        expect(cm.getChannelInfo('invalid-key-no-allocation')).to.equal(null);
+      } finally {
+        cm.destroy();
+      }
+    });
+
     it('close() clears heavy channel state but keeps the tombstone flag', () => {
       const cm = new ChannelManager();
       try {
@@ -818,6 +1113,7 @@ describe('Relay Server', function () {
         cm.join('unit-close', 'sock-d', 'dapp', 'YQ==');
         const routed = cm.routeMessage('unit-close', 'sock-d', {
           id: 'unit-close',
+          clientType: 'dapp',
           message: 'x',
           seq: 0,
         });
@@ -840,7 +1136,12 @@ describe('Relay Server', function () {
         expect(cm.getActiveChannelCount()).to.equal(0);
         // ... and routing through it is refused.
         expect(
-          cm.routeMessage('unit-close', 'sock-d', { id: 'unit-close', message: 'y', seq: 1 }).error
+          cm.routeMessage('unit-close', 'sock-d', {
+            id: 'unit-close',
+            clientType: 'dapp',
+            message: 'y',
+            seq: 1,
+          }).error
         ).to.equal('Channel terminated');
       } finally {
         clearInterval(cm.cleanupTimer);
@@ -865,6 +1166,134 @@ describe('Relay Server', function () {
       } finally {
         clearInterval(cm.cleanupTimer);
       }
+    });
+  });
+
+  describe('ChannelManager buffered-byte budgets', () => {
+    const budgetKeys = [
+      'RELAY_MAX_BUFFERED_BYTES_PER_CHANNEL',
+      'RELAY_MAX_BUFFERED_BYTES_PER_IP',
+      'RELAY_MAX_BUFFERED_BYTES_GLOBAL',
+    ];
+
+    function withBudgets(overrides, fn) {
+      const originals = {};
+      for (const key of budgetKeys) originals[key] = CONFIG[key];
+      Object.assign(CONFIG, overrides);
+      try {
+        fn();
+      } finally {
+        Object.assign(CONFIG, originals);
+      }
+    }
+
+    it('enforces the per-channel byte cap and releases accounting on delivery', () => {
+      const payload = {
+        id: 'bytes-ch',
+        clientType: 'dapp',
+        message: 'x'.repeat(64),
+      };
+      const bytes = Buffer.byteLength(JSON.stringify(payload));
+
+      withBudgets(
+        {
+          RELAY_MAX_BUFFERED_BYTES_PER_CHANNEL: bytes,
+          RELAY_MAX_BUFFERED_BYTES_PER_IP: bytes * 10,
+          RELAY_MAX_BUFFERED_BYTES_GLOBAL: bytes * 10,
+        },
+        () => {
+          const cm = new ChannelManager();
+          try {
+            cm.join('bytes-ch', 'dapp-socket', 'dapp');
+            expect(cm.routeMessage('bytes-ch', 'dapp-socket', payload, '192.0.2.1').buffered).to.be
+              .true;
+            expect(cm.getStats().totalBufferedBytes).to.equal(bytes);
+
+            const rejected = cm.routeMessage('bytes-ch', 'dapp-socket', payload, '192.0.2.1');
+            expect(rejected.error).to.include('Channel buffered-byte');
+
+            const walletJoin = cm.join('bytes-ch', 'wallet-socket', 'wallet');
+            expect(walletJoin.success).to.be.true;
+            expect(walletJoin.bufferedMessages).to.have.length(1);
+            expect(cm.getStats().totalBufferedBytes).to.equal(0);
+          } finally {
+            cm.destroy();
+          }
+        }
+      );
+    });
+
+    it('retains live-egress accounting until transport drain after a leave', () => {
+      const cm = new ChannelManager({ canSocketReceive: () => true });
+      try {
+        cm.join('leave-inflight', 'dapp-socket', 'dapp');
+        cm.join('leave-inflight', 'wallet-socket', 'wallet');
+        const routed = cm.routeMessage(
+          'leave-inflight',
+          'dapp-socket',
+          { id: 'leave-inflight', clientType: 'dapp', message: 'ciphertext' },
+          '192.0.2.1'
+        );
+        expect(routed.targetSocketId).to.equal('wallet-socket');
+        const reserved = cm.getStats().totalDirectInflightBytes;
+        expect(reserved).to.be.greaterThan(0);
+
+        cm.leave('wallet-socket', 'leave-inflight');
+        expect(cm.getStats().totalDirectInflightBytes).to.equal(reserved);
+
+        cm.releaseDirectDelivery('wallet-socket');
+        expect(cm.getStats().totalDirectInflightBytes).to.equal(0);
+      } finally {
+        cm.destroy();
+      }
+    });
+
+    it('enforces per-IP and global buffered-byte caps across channels', () => {
+      const first = { id: 'budget-a', clientType: 'dapp', message: 'x'.repeat(32) };
+      const second = { id: 'budget-b', clientType: 'dapp', message: 'x'.repeat(32) };
+      const bytes = Buffer.byteLength(JSON.stringify(first));
+
+      withBudgets(
+        {
+          RELAY_MAX_BUFFERED_BYTES_PER_CHANNEL: bytes * 10,
+          RELAY_MAX_BUFFERED_BYTES_PER_IP: bytes,
+          RELAY_MAX_BUFFERED_BYTES_GLOBAL: bytes * 10,
+        },
+        () => {
+          const cm = new ChannelManager();
+          try {
+            cm.join('budget-a', 'socket-a', 'dapp');
+            cm.join('budget-b', 'socket-b', 'dapp');
+            expect(cm.routeMessage('budget-a', 'socket-a', first, '192.0.2.1').buffered).to.be.true;
+            expect(cm.routeMessage('budget-b', 'socket-b', second, '192.0.2.1').error).to.include(
+              'Per-IP buffered-byte'
+            );
+          } finally {
+            cm.destroy();
+          }
+        }
+      );
+
+      withBudgets(
+        {
+          RELAY_MAX_BUFFERED_BYTES_PER_CHANNEL: bytes * 10,
+          RELAY_MAX_BUFFERED_BYTES_PER_IP: bytes * 10,
+          RELAY_MAX_BUFFERED_BYTES_GLOBAL: bytes,
+        },
+        () => {
+          const cm = new ChannelManager();
+          try {
+            cm.join('budget-a', 'socket-a', 'dapp');
+            cm.join('budget-b', 'socket-b', 'dapp');
+            expect(cm.routeMessage('budget-a', 'socket-a', first, '192.0.2.1').buffered).to.be.true;
+            expect(cm.routeMessage('budget-b', 'socket-b', second, '192.0.2.2').error).to.include(
+              'Global buffered-byte'
+            );
+          } finally {
+            cm.destroy();
+          }
+        }
+      );
     });
   });
 });

--- a/test/routes/app.routes.test.js
+++ b/test/routes/app.routes.test.js
@@ -1,0 +1,32 @@
+import * as chai from 'chai';
+import axios from 'axios';
+import { default as chaiHttp, request } from 'chai-http';
+import sinon from 'sinon';
+import { app } from '../../src/app.js';
+
+chai.use(chaiHttp);
+const { expect } = chai;
+
+describe('application proxy routes', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('bounds transaction-history pagination, response bytes, and redirects', async () => {
+    const getStub = sinon.stub(axios, 'get').resolves({ data: { transactions: [] } });
+
+    const response = await request
+      .execute(app)
+      .post('/api/tx-history')
+      .send({ address: `Q${'a'.repeat(40)}`, page: 1_000_000, limit: 10_000 });
+
+    expect(response).to.have.status(200);
+    expect(getStub.calledOnce).to.equal(true);
+    expect(getStub.firstCall.args[1]).to.deep.include({
+      params: { page: 100_000, limit: 50 },
+      timeout: 8000,
+      maxContentLength: 2 * 1024 * 1024,
+      maxRedirects: 0,
+    });
+  });
+});

--- a/test/routes/health.routes.test.js
+++ b/test/routes/health.routes.test.js
@@ -4,18 +4,27 @@ import { default as chaiHttp, request } from 'chai-http';
 chai.use(chaiHttp);
 
 import { app } from '../../src/app.js';
+import { CONFIG } from '../../src/config/index.js';
 import { healthMonitor, HEALTH_STATES } from '../../src/services/rpc/healthMonitor.js';
 
 chai.use(chaiHttp);
 const { expect } = chai;
 
 describe('Health Routes', () => {
+  const originalRequiredNetworks = [...CONFIG.RPC_REQUIRED_NETWORKS];
+
   afterEach(() => {
     healthMonitor.__resetForTesting();
+    CONFIG.RPC_REQUIRED_NETWORKS = [...originalRequiredNetworks];
   });
 
-  it('should return status ok with per-endpoint snapshot (url redacted) when at least one endpoint is selectable', async () => {
+  it('returns ok with a redacted snapshot when every required network is up', async () => {
     healthMonitor.__setEndpointsForTesting('testnet', ['http://example.test:8545']);
+    healthMonitor.__forceStateForTesting(
+      'testnet',
+      'http://example.test:8545',
+      HEALTH_STATES.STATE_UP
+    );
     const res = await request.execute(app).get('/health');
     expect(res).to.have.status(200);
     expect(res.body.status).to.equal('ok');
@@ -23,14 +32,28 @@ describe('Health Routes', () => {
     expect(res.body.endpoints.testnet).to.be.an('array').with.lengthOf(1);
     expect(res.body.endpoints.testnet[0]).to.include({
       index: 0,
-      state: HEALTH_STATES.STATE_UNKNOWN,
+      state: HEALTH_STATES.STATE_UP,
     });
     // Internal RPC URL is intentionally stripped from the public response
     // so anonymous callers can't enumerate backend infrastructure.
     expect(res.body.endpoints.testnet[0]).to.not.have.property('url');
   });
 
-  it('should return 503 degraded when every configured endpoint is down or stalled', async () => {
+  it('returns 503 degraded when a required network is stalled', async () => {
+    healthMonitor.__setEndpointsForTesting('testnet', ['http://down.test:8545']);
+    healthMonitor.__forceStateForTesting(
+      'testnet',
+      'http://down.test:8545',
+      HEALTH_STATES.STATE_STALLED
+    );
+
+    const res = await request.execute(app).get('/health');
+    expect(res).to.have.status(503);
+    expect(res.body.status).to.equal('degraded');
+    expect(res.body.endpoints.testnet[0].state).to.equal(HEALTH_STATES.STATE_STALLED);
+  });
+
+  it('keeps process liveness healthy when RPC readiness is degraded', async () => {
     healthMonitor.__setEndpointsForTesting('testnet', ['http://down.test:8545']);
     healthMonitor.__forceStateForTesting(
       'testnet',
@@ -38,9 +61,49 @@ describe('Health Routes', () => {
       HEALTH_STATES.STATE_DOWN
     );
 
+    const readiness = await request.execute(app).get('/health');
+    const liveness = await request.execute(app).get('/health/live');
+
+    expect(readiness).to.have.status(503);
+    expect(liveness).to.have.status(200);
+    expect(liveness.body.status).to.equal('alive');
+  });
+
+  it('does not expose credential-bearing fetch failures', async () => {
+    const secret = 'REVIEW_SECRET';
+    healthMonitor.__setEndpointsForTesting('testnet', [
+      `https://wallet:${secret}@example.invalid/rpc`,
+    ]);
+    const endpoint = healthMonitor.networks.get('testnet')[0];
+    healthMonitor.applyFailure(
+      'testnet',
+      endpoint,
+      new TypeError(`fetch failed for https://wallet:${secret}@example.invalid/rpc`)
+    );
+
+    const res = await request.execute(app).get('/health');
+    expect(res).to.have.status(503);
+    expect(JSON.stringify(res.body)).not.to.include(secret);
+    expect(res.body.endpoints.testnet[0].lastError).to.equal('upstream health check failed');
+  });
+
+  it('requires every configured required network to be up', async () => {
+    CONFIG.RPC_REQUIRED_NETWORKS = ['testnet', 'mainnet'];
+    healthMonitor.__setEndpointsForTesting('testnet', ['http://testnet.test:8545']);
+    healthMonitor.__setEndpointsForTesting('mainnet', ['http://mainnet.test:8545']);
+    healthMonitor.__forceStateForTesting(
+      'testnet',
+      'http://testnet.test:8545',
+      HEALTH_STATES.STATE_UP
+    );
+    healthMonitor.__forceStateForTesting(
+      'mainnet',
+      'http://mainnet.test:8545',
+      HEALTH_STATES.STATE_DOWN
+    );
+
     const res = await request.execute(app).get('/health');
     expect(res).to.have.status(503);
     expect(res.body.status).to.equal('degraded');
-    expect(res.body.endpoints.testnet[0].state).to.equal(HEALTH_STATES.STATE_DOWN);
   });
 });

--- a/test/routes/ipfs.routes.test.js
+++ b/test/routes/ipfs.routes.test.js
@@ -1,4 +1,5 @@
 import * as chai from 'chai';
+import { createServer, request as httpRequest, ServerResponse } from 'node:http';
 import sinon from 'sinon';
 import { default as chaiHttp, request } from 'chai-http';
 
@@ -6,6 +7,7 @@ chai.use(chaiHttp);
 const { expect } = chai;
 
 import { app } from '../../src/app.js';
+import { CONFIG } from '../../src/config/index.js';
 
 /**
  * Build a stand-in for the Fetch API Response object that lets us drive
@@ -47,14 +49,87 @@ function buildFetchResponse({
   };
 }
 
+function getFromServer(port, path) {
+  return new Promise((resolve, reject) => {
+    const client = httpRequest(
+      {
+        host: '127.0.0.1',
+        port,
+        path,
+        method: 'GET',
+        headers: { Connection: 'close' },
+      },
+      (response) => {
+        const chunks = [];
+        response.on('data', (chunk) => chunks.push(chunk));
+        response.on('end', () => {
+          resolve({ status: response.statusCode, body: Buffer.concat(chunks).toString('utf8') });
+        });
+      }
+    );
+    client.on('error', reject);
+    client.end();
+  });
+}
+
+function getFromServerExpectDisconnect(port, path) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+    const client = httpRequest(
+      {
+        host: '127.0.0.1',
+        port,
+        path,
+        method: 'GET',
+        headers: { Connection: 'close' },
+      },
+      (response) => {
+        const chunks = [];
+        response.on('data', (chunk) => chunks.push(chunk));
+        response.on('aborted', () => {
+          finish({ disconnected: true, status: response.statusCode, body: Buffer.concat(chunks) });
+        });
+        response.on('error', () => {
+          finish({ disconnected: true, status: response.statusCode, body: Buffer.concat(chunks) });
+        });
+        response.on('end', () => {
+          finish({ disconnected: false, status: response.statusCode, body: Buffer.concat(chunks) });
+        });
+      }
+    );
+    client.on('error', (error) => {
+      if (settled) return;
+      if (error.code === 'ECONNRESET') {
+        finish({ disconnected: true, status: undefined, body: Buffer.alloc(0) });
+        return;
+      }
+      reject(error);
+    });
+    client.end();
+  });
+}
+
 describe('IPFS Routes', () => {
   let fetchStub;
+  let originalLimits;
 
   beforeEach(() => {
+    originalLimits = {
+      IPFS_FETCH_TIMEOUT_MS: CONFIG.IPFS_FETCH_TIMEOUT_MS,
+      IPFS_MAX_CONCURRENT: CONFIG.IPFS_MAX_CONCURRENT,
+      IPFS_MAX_INFLIGHT_BYTES: CONFIG.IPFS_MAX_INFLIGHT_BYTES,
+      IPFS_MAX_SIZE_BYTES: CONFIG.IPFS_MAX_SIZE_BYTES,
+    };
     fetchStub = sinon.stub(globalThis, 'fetch');
   });
 
   afterEach(() => {
+    Object.assign(CONFIG, originalLimits);
     sinon.restore();
   });
 
@@ -93,6 +168,7 @@ describe('IPFS Routes', () => {
     expect(res.body.toString()).to.equal('PNGDATA');
     expect(fetchStub.calledOnce).to.equal(true);
     expect(fetchStub.firstCall.args[0]).to.match(new RegExp(`/ipfs/${cid}$`));
+    expect(fetchStub.firstCall.args[1]?.redirect).to.equal('error');
   });
 
   it('proxies CIDv1 with a path suffix', async () => {
@@ -135,12 +211,21 @@ describe('IPFS Routes', () => {
       })
     );
 
+    const server = createServer(app);
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
     const cid = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
-    const res = await request.execute(app).get(`/api/ipfs/${cid}`);
+    try {
+      const result = await getFromServerExpectDisconnect(address.port, `/api/ipfs/${cid}`);
 
-    expect(res).to.have.status(413);
-    expect(res.body.error).to.equal('too large');
-    expect(res.body.size).to.be.greaterThan(10 * 1024 * 1024);
+      // Bytes already streamed cannot be replaced with a 413 envelope. The
+      // proxy enforces the cap by terminating the partial HTTP response.
+      expect(result.disconnected).to.equal(true);
+      expect(result.body.byteLength).to.equal(10 * 1024 * 1024);
+    } finally {
+      server.closeAllConnections();
+      await new Promise((resolve) => server.close(resolve));
+    }
   });
 
   it('returns 504 on gateway timeout', async () => {
@@ -256,6 +341,50 @@ describe('IPFS Routes', () => {
     expect(res.body.error).to.equal('gateway stream error');
   });
 
+  it('terminates a partial response when a later stream chunk is non-binary', async () => {
+    let index = 0;
+    const chunks = [Buffer.from('partial'), 'not-binary'];
+    fetchStub.resolves({
+      ok: true,
+      status: 200,
+      headers: {
+        get(name) {
+          const normalized = name.toLowerCase();
+          if (normalized === 'content-type') return 'image/png';
+          if (normalized === 'content-length') return '100';
+          return null;
+        },
+      },
+      body: {
+        getReader() {
+          return {
+            async read() {
+              if (index >= chunks.length) return { done: true, value: undefined };
+              return { done: false, value: chunks[index++] };
+            },
+            async cancel() {
+              index = chunks.length;
+            },
+          };
+        },
+      },
+    });
+
+    const server = createServer(app);
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    const cid = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
+    try {
+      const result = await getFromServerExpectDisconnect(address.port, `/api/ipfs/${cid}`);
+
+      expect(result.disconnected).to.equal(true);
+      expect(result.body.toString('utf8')).to.equal('partial');
+    } finally {
+      server.closeAllConnections();
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+
   it('returns 404 when the gateway returns 404', async () => {
     fetchStub.resolves({
       ok: false,
@@ -268,5 +397,122 @@ describe('IPFS Routes', () => {
 
     expect(res).to.have.status(404);
     expect(res.body.error).to.equal('gateway error');
+  });
+
+  it('rejects a second fetch while the concurrency budget is occupied', async () => {
+    CONFIG.IPFS_MAX_CONCURRENT = 1;
+    CONFIG.IPFS_MAX_INFLIGHT_BYTES = CONFIG.IPFS_MAX_SIZE_BYTES * 2;
+
+    let releaseFetch;
+    let signalFetchStarted;
+    const fetchStarted = new Promise((resolve) => {
+      signalFetchStarted = resolve;
+    });
+    fetchStub.callsFake(
+      () =>
+        new Promise((resolve) => {
+          releaseFetch = resolve;
+          signalFetchStarted();
+        })
+    );
+
+    const server = createServer(app);
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    const cid = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
+    const path = `/api/ipfs/${cid}`;
+    try {
+      const firstRequest = getFromServer(address.port, path);
+      await fetchStarted;
+
+      const busy = await getFromServer(address.port, path);
+      expect(busy.status).to.equal(503);
+      expect(JSON.parse(busy.body).error).to.equal('IPFS proxy busy');
+      expect(fetchStub.callCount).to.equal(1);
+
+      releaseFetch(buildFetchResponse());
+      expect((await firstRequest).status).to.equal(200);
+    } finally {
+      server.closeAllConnections();
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+
+  it('releases its fetch slot when a slow downstream client hits the deadline', async () => {
+    CONFIG.IPFS_FETCH_TIMEOUT_MS = 100;
+    CONFIG.IPFS_MAX_CONCURRENT = 1;
+    CONFIG.IPFS_MAX_INFLIGHT_BYTES = CONFIG.IPFS_MAX_SIZE_BYTES;
+    fetchStub.resolves(buildFetchResponse({ chunks: [Buffer.alloc(1024)] }));
+
+    const originalWrite = ServerResponse.prototype.write;
+    let blockOneWrite = true;
+    sinon.stub(ServerResponse.prototype, 'write').callsFake(function (...args) {
+      if (blockOneWrite) {
+        blockOneWrite = false;
+        return false;
+      }
+      return Reflect.apply(originalWrite, this, args);
+    });
+
+    const server = createServer(app);
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    const cid = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
+    const path = `/api/ipfs/${cid}`;
+    try {
+      const timedOut = await getFromServer(address.port, path);
+      expect(timedOut.status).to.equal(504);
+
+      const next = await getFromServer(address.port, path);
+      expect(next.status).to.equal(200);
+      expect(fetchStub.callCount).to.equal(2);
+    } finally {
+      server.closeAllConnections();
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+
+  it('aborts the gateway request when the client disconnects', async () => {
+    let signalFetchStarted;
+    const fetchStarted = new Promise((resolve) => {
+      signalFetchStarted = resolve;
+    });
+    let signalAborted;
+    const aborted = new Promise((resolve) => {
+      signalAborted = resolve;
+    });
+    fetchStub.callsFake((_url, options) => {
+      signalFetchStarted();
+      return new Promise((_resolve, reject) => {
+        options.signal.addEventListener(
+          'abort',
+          () => {
+            signalAborted();
+            const err = new Error('aborted');
+            err.name = 'AbortError';
+            reject(err);
+          },
+          { once: true }
+        );
+      });
+    });
+
+    const server = createServer(app);
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    const cid = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
+    const client = httpRequest({
+      host: '127.0.0.1',
+      port: address.port,
+      path: `/api/ipfs/${cid}`,
+      method: 'GET',
+    });
+    client.on('error', () => {});
+    client.end();
+
+    await fetchStarted;
+    client.destroy();
+    await aborted;
+    await new Promise((resolve) => server.close(resolve));
   });
 });

--- a/test/routes/rpc.routes.test.js
+++ b/test/routes/rpc.routes.test.js
@@ -1,20 +1,29 @@
 import * as chai from 'chai';
+import { createServer, request as httpRequest } from 'node:http';
 import { default as chaiHttp, request } from 'chai-http';
 import sinon from 'sinon';
 import { app } from '../../src/app.js';
+import { CONFIG } from '../../src/config/index.js';
 import { rpcService } from '../../src/services/rpc.service.js';
+import { HttpError } from '../../src/utils/guards.js';
 
 chai.use(chaiHttp);
 const { expect } = chai;
 
 describe('RPC Routes', () => {
   let rpcServiceStub;
+  let originalRateLimits;
 
   beforeEach(() => {
+    originalRateLimits = {
+      RPC_RATE_LIMIT_PER_MINUTE: CONFIG.RPC_RATE_LIMIT_PER_MINUTE,
+      RPC_WRITE_RATE_LIMIT_PER_MINUTE: CONFIG.RPC_WRITE_RATE_LIMIT_PER_MINUTE,
+    };
     rpcServiceStub = sinon.stub(rpcService, 'executeRPC');
   });
 
   afterEach(() => {
+    Object.assign(CONFIG, originalRateLimits);
     rpcServiceStub.restore();
   });
 
@@ -62,7 +71,19 @@ describe('RPC Routes', () => {
       .send({ method: 'qrl_blockNumber', params: [] });
 
     expect(res).to.have.status(500);
-    expect(res.body.error.message).to.equal('RPC Error');
+    expect(res.body.error.message).to.equal('Internal Server Error');
+  });
+
+  it('preserves deterministic upstream and admission error statuses', async () => {
+    for (const status of [502, 503]) {
+      rpcServiceStub.rejects(new HttpError(status, status === 502 ? 'upstream failed' : 'busy'));
+      const res = await request
+        .execute(app)
+        .post(`/api/qrl-rpc/status-${status}`)
+        .send({ method: 'qrl_blockNumber', params: [] });
+      expect(res).to.have.status(status);
+      rpcServiceStub.resetBehavior();
+    }
   });
 
   it('should reject disallowed RPC methods', async () => {
@@ -74,6 +95,150 @@ describe('RPC Routes', () => {
     expect(res).to.have.status(403);
     expect(res.body.error.code).to.equal(-32601);
     expect(res.body.error.message).to.include('Method not allowed');
+  });
+
+  it('does not expose unsigned qrl_sendTransaction', async () => {
+    const res = await request
+      .execute(app)
+      .post('/api/qrl-rpc/dev')
+      .send({ method: 'qrl_sendTransaction', params: [{ from: 'Q' + 'a'.repeat(40) }] });
+
+    expect(res).to.have.status(403);
+    expect(res.body.error.code).to.equal(-32601);
+    expect(rpcServiceStub.called).to.equal(false);
+  });
+
+  it('rejects numeric-to-dynamic qrl_getLogs scans', async () => {
+    for (const filter of [
+      { fromBlock: '0x1', toBlock: 'latest' },
+      { fromBlock: '0x1', toBlock: 'pending' },
+      { fromBlock: '0x1' },
+    ]) {
+      const res = await request
+        .execute(app)
+        .post('/api/qrl-rpc/dev')
+        .send({ method: 'qrl_getLogs', params: [filter] });
+      expect(res).to.have.status(400);
+      expect(res.body.error.message).to.include('numeric toBlock');
+    }
+    expect(rpcServiceStub.called).to.equal(false);
+  });
+
+  it('allows a bounded numeric qrl_getLogs range', async () => {
+    rpcServiceStub.resolves({ jsonrpc: '2.0', id: 1, result: [] });
+    const res = await request
+      .execute(app)
+      .post('/api/qrl-rpc/dev')
+      .send({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'qrl_getLogs',
+        params: [{ fromBlock: '0x100', toBlock: '0x200' }],
+      });
+
+    expect(res).to.have.status(200);
+    expect(rpcServiceStub.calledOnce).to.equal(true);
+  });
+
+  it('enforces the 50KB JSON limit for chunked bodies without Content-Length', async () => {
+    const server = createServer(app);
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    try {
+      const address = server.address();
+      const body = JSON.stringify({
+        method: 'qrl_call',
+        params: [{ to: 'Q' + 'a'.repeat(40), data: 'x'.repeat(60 * 1024) }],
+      });
+      const status = await new Promise((resolve, reject) => {
+        const req = httpRequest(
+          {
+            host: '127.0.0.1',
+            port: address.port,
+            path: '/api/qrl-rpc/dev',
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Transfer-Encoding': 'chunked',
+            },
+          },
+          (res) => {
+            res.resume();
+            res.on('end', () => resolve(res.statusCode));
+          }
+        );
+        req.on('error', reject);
+        const midpoint = Math.floor(body.length / 2);
+        req.write(body.slice(0, midpoint));
+        req.end(body.slice(midpoint));
+      });
+
+      expect(status).to.equal(413);
+      expect(rpcServiceStub.called).to.equal(false);
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+
+  it('does not let spoofed forwarding headers evade write rate limits', async () => {
+    const originalTrustedProxies = [...CONFIG.TRUSTED_PROXY_CIDRS];
+    CONFIG.TRUSTED_PROXY_CIDRS = [];
+    rpcServiceStub.resolves({ jsonrpc: '2.0', id: 1, result: '0x1' });
+    try {
+      let lastResponse;
+      for (let i = 0; i < 11; i++) {
+        lastResponse = await request
+          .execute(app)
+          .post('/api/qrl-rpc/mainnet')
+          .set('X-Forwarded-For', `198.51.100.${i + 1}`)
+          .send({ id: i, method: 'qrl_sendRawTransaction', params: ['0x01'] });
+      }
+      expect(lastResponse).to.have.status(429);
+      expect(rpcServiceStub.callCount).to.equal(10);
+    } finally {
+      CONFIG.TRUSTED_PROXY_CIDRS = originalTrustedProxies;
+    }
+  });
+
+  it('charges invalid and batch requests to the general admission limit', async () => {
+    CONFIG.RPC_RATE_LIMIT_PER_MINUTE = 3;
+    const originalTrustedProxies = [...CONFIG.TRUSTED_PROXY_CIDRS];
+    CONFIG.TRUSTED_PROXY_CIDRS = ['loopback'];
+    const clientIp = '198.51.100.244';
+
+    try {
+      const malformed = await request
+        .execute(app)
+        .post('/api/qrl-rpc/invalid-a')
+        .set('X-Forwarded-For', clientIp)
+        .set('Content-Type', 'application/json')
+        .send('{');
+      expect(malformed).to.have.status(400);
+
+      const invalid = await request
+        .execute(app)
+        .post('/api/qrl-rpc/invalid-b')
+        .set('X-Forwarded-For', clientIp)
+        .send({ method: 'not_allowed', params: [] });
+      expect(invalid).to.have.status(403);
+
+      const batch = await request
+        .execute(app)
+        .post('/api/qrl-rpc/invalid-c')
+        .set('X-Forwarded-For', clientIp)
+        .send([{ method: 'qrl_blockNumber', params: [] }]);
+      expect(batch).to.have.status(400);
+
+      const limited = await request
+        .execute(app)
+        .post('/api/qrl-rpc/invalid-d')
+        .set('X-Forwarded-For', clientIp)
+        .send({ method: 'still_not_allowed', params: [] });
+      expect(limited).to.have.status(429);
+      expect(limited.body.error.code).to.equal(-32005);
+      expect(rpcServiceStub.called).to.equal(false);
+    } finally {
+      CONFIG.TRUSTED_PROXY_CIDRS = originalTrustedProxies;
+    }
   });
 
   it('should reject batch requests', async () => {

--- a/test/services/notifier.test.js
+++ b/test/services/notifier.test.js
@@ -1,0 +1,17 @@
+import * as chai from 'chai';
+
+const { expect } = chai;
+
+import { redactEndpointForLogs } from '../../src/services/notifier.js';
+
+describe('RPC health notifier', () => {
+  it('removes endpoint credentials, paths, queries, and fragments from log labels', () => {
+    const endpoint = 'https://wallet-user:secret@rpc.example/v1/api-key?token=secret#fragment';
+
+    expect(redactEndpointForLogs(endpoint)).to.equal('https://rpc.example');
+  });
+
+  it('does not echo malformed endpoint configuration', () => {
+    expect(redactEndpointForLogs('not a URL with secret data')).to.equal('[invalid RPC endpoint]');
+  });
+});

--- a/test/services/rpc.service.test.js
+++ b/test/services/rpc.service.test.js
@@ -7,8 +7,52 @@ import { healthMonitor, HEALTH_STATES } from '../../src/services/rpc/healthMonit
 
 const { expect } = chai;
 
+function buildRpcResponse({ ok = true, status = 200, contentLength, chunks } = {}) {
+  const body = Buffer.from(JSON.stringify({ jsonrpc: '2.0', id: 1, result: '0x1' }));
+  const queue = [...(chunks ?? [body])];
+  let index = 0;
+  return {
+    ok,
+    status,
+    headers: {
+      get(name) {
+        if (name.toLowerCase() === 'content-length') {
+          return String(
+            contentLength ?? queue.reduce((total, chunk) => total + chunk.byteLength, 0)
+          );
+        }
+        return null;
+      },
+    },
+    body: {
+      getReader() {
+        return {
+          async read() {
+            if (index >= queue.length) return { done: true, value: undefined };
+            return { done: false, value: queue[index++] };
+          },
+          async cancel() {
+            index = queue.length;
+          },
+        };
+      },
+    },
+  };
+}
+
 describe('RPC Service', () => {
+  let originalRpcLimits;
+
+  beforeEach(() => {
+    originalRpcLimits = {
+      RPC_MAX_RESPONSE_BYTES: CONFIG.RPC_MAX_RESPONSE_BYTES,
+      RPC_MAX_CONCURRENT: CONFIG.RPC_MAX_CONCURRENT,
+      RPC_MAX_INFLIGHT_BYTES: CONFIG.RPC_MAX_INFLIGHT_BYTES,
+    };
+  });
+
   afterEach(() => {
+    Object.assign(CONFIG, originalRpcLimits);
     sinon.restore();
     cache.flushAll();
     healthMonitor.__resetForTesting();
@@ -164,7 +208,218 @@ describe('RPC Service', () => {
     });
   });
 
+  describe('upstream response admission', () => {
+    it('parses a valid response from bounded chunks', async () => {
+      const encoded = Buffer.from(JSON.stringify({ jsonrpc: '2.0', id: 7, result: '0x77' }));
+      sinon.stub(globalThis, 'fetch').resolves(
+        buildRpcResponse({
+          chunks: [encoded.subarray(0, 10), encoded.subarray(10)],
+        })
+      );
+
+      const result = await rpcService.makeRPCCall(
+        'http://upstream.test:8545',
+        'qrl_blockNumber',
+        [],
+        7
+      );
+
+      expect(result).to.deep.equal({ jsonrpc: '2.0', id: 7, result: '0x77' });
+      expect(globalThis.fetch.firstCall.args[1].redirect).to.equal('error');
+    });
+
+    it('returns 502 when declared or streamed response bytes exceed the cap', async () => {
+      CONFIG.RPC_MAX_RESPONSE_BYTES = 32;
+      CONFIG.RPC_MAX_INFLIGHT_BYTES = 64;
+      const fetchStub = sinon.stub(globalThis, 'fetch');
+      fetchStub.onFirstCall().resolves(buildRpcResponse({ contentLength: 33 }));
+
+      let declaredError;
+      try {
+        await rpcService.makeRPCCall('http://upstream.test:8545', 'qrl_blockNumber', []);
+      } catch (err) {
+        declaredError = err;
+      }
+      expect(declaredError).to.include({ status: 502, message: 'RPC upstream response too large' });
+
+      const encoded = Buffer.from(
+        JSON.stringify({ jsonrpc: '2.0', id: 1, result: 'x'.repeat(64) })
+      );
+      fetchStub.onSecondCall().resolves(
+        buildRpcResponse({
+          contentLength: 1,
+          chunks: [encoded.subarray(0, 20), encoded.subarray(20)],
+        })
+      );
+
+      let streamedError;
+      try {
+        await rpcService.makeRPCCall('http://upstream.test:8545', 'qrl_blockNumber', []);
+      } catch (err) {
+        streamedError = err;
+      }
+      expect(streamedError).to.include({ status: 502, message: 'RPC upstream response too large' });
+    });
+
+    it('returns 502 for invalid upstream JSON', async () => {
+      sinon
+        .stub(globalThis, 'fetch')
+        .resolves(buildRpcResponse({ chunks: [Buffer.from('{"jsonrpc":')] }));
+
+      let rpcError;
+      try {
+        await rpcService.makeRPCCall('http://upstream.test:8545', 'qrl_blockNumber', []);
+      } catch (err) {
+        rpcError = err;
+      }
+      expect(rpcError).to.include({ status: 502, message: 'RPC upstream returned invalid JSON' });
+    });
+
+    it('returns 502 and cancels an invalid UTF-8 response stream', async () => {
+      let cancelled = false;
+      let delivered = false;
+      sinon.stub(globalThis, 'fetch').resolves({
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        body: {
+          getReader() {
+            return {
+              async read() {
+                if (delivered) return { done: true, value: undefined };
+                delivered = true;
+                return { done: false, value: Uint8Array.from([0xff]) };
+              },
+              async cancel() {
+                cancelled = true;
+              },
+            };
+          },
+        },
+      });
+
+      let rpcError;
+      try {
+        await rpcService.makeRPCCall('http://upstream.test:8545', 'qrl_blockNumber', []);
+      } catch (err) {
+        rpcError = err;
+      }
+
+      await Promise.resolve();
+      expect(rpcError).to.include({
+        status: 502,
+        message: 'RPC upstream returned an invalid response body',
+      });
+      expect(cancelled).to.equal(true);
+    });
+
+    it('returns 503 when the concurrency cap is occupied and releases the slot', async () => {
+      CONFIG.RPC_MAX_RESPONSE_BYTES = 1024;
+      CONFIG.RPC_MAX_CONCURRENT = 1;
+      CONFIG.RPC_MAX_INFLIGHT_BYTES = 2048;
+      let resolveFetch;
+      let signalStarted;
+      const started = new Promise((resolve) => {
+        signalStarted = resolve;
+      });
+      const fetchStub = sinon.stub(globalThis, 'fetch');
+      fetchStub.onFirstCall().callsFake(
+        () =>
+          new Promise((resolve) => {
+            resolveFetch = resolve;
+            signalStarted();
+          })
+      );
+      fetchStub.onSecondCall().resolves(buildRpcResponse());
+
+      const first = rpcService.makeRPCCall('http://upstream.test:8545', 'qrl_blockNumber', []);
+      await started;
+
+      let busyError;
+      try {
+        await rpcService.makeRPCCall('http://upstream.test:8545', 'qrl_blockNumber', []);
+      } catch (err) {
+        busyError = err;
+      }
+      expect(busyError).to.include({ status: 503, message: 'RPC proxy busy' });
+      expect(fetchStub.callCount).to.equal(1);
+
+      resolveFetch(buildRpcResponse());
+      await first;
+      await rpcService.makeRPCCall('http://upstream.test:8545', 'qrl_blockNumber', []);
+      expect(fetchStub.callCount).to.equal(2);
+    });
+
+    it('returns 503 when the aggregate byte reservation is occupied', async () => {
+      CONFIG.RPC_MAX_RESPONSE_BYTES = 1024;
+      CONFIG.RPC_MAX_CONCURRENT = 4;
+      CONFIG.RPC_MAX_INFLIGHT_BYTES = 1024;
+      let resolveFetch;
+      let signalStarted;
+      const started = new Promise((resolve) => {
+        signalStarted = resolve;
+      });
+      const fetchStub = sinon.stub(globalThis, 'fetch');
+      fetchStub.onFirstCall().callsFake(
+        () =>
+          new Promise((resolve) => {
+            resolveFetch = resolve;
+            signalStarted();
+          })
+      );
+
+      const first = rpcService.makeRPCCall('http://upstream.test:8545', 'qrl_blockNumber', []);
+      await started;
+
+      let busyError;
+      try {
+        await rpcService.makeRPCCall('http://upstream.test:8545', 'qrl_blockNumber', []);
+      } catch (err) {
+        busyError = err;
+      }
+      expect(busyError).to.include({ status: 503, message: 'RPC proxy busy' });
+      expect(fetchStub.callCount).to.equal(1);
+
+      resolveFetch(buildRpcResponse());
+      await first;
+    });
+  });
+
   describe('failover behavior', () => {
+    it('never lets client-selected success or failure mutate endpoint health', async () => {
+      healthMonitor.__setEndpointsForTesting('testnet', ['http://primary.test:8545']);
+      healthMonitor.__forceStateForTesting(
+        'testnet',
+        'http://primary.test:8545',
+        HEALTH_STATES.STATE_STALLED
+      );
+      const stub = sinon.stub(rpcService, 'makeRPCCall');
+      stub.onFirstCall().resolves({ jsonrpc: '2.0', id: 1, result: '0x100' });
+      stub.onSecondCall().resolves({ jsonrpc: '2.0', id: 2, result: '0x101' });
+      stub.onThirdCall().rejects(new Error('client request failed'));
+
+      await rpcService.executeRPC('testnet', 'qrl_blockNumber', []);
+      expect(healthMonitor.getSnapshot().testnet[0].state).to.equal(HEALTH_STATES.STATE_STALLED);
+
+      healthMonitor.__forceStateForTesting(
+        'testnet',
+        'http://primary.test:8545',
+        HEALTH_STATES.STATE_DOWN
+      );
+      await rpcService.executeRPC('testnet', 'qrl_blockNumber', []);
+      expect(healthMonitor.getSnapshot().testnet[0].state).to.equal(HEALTH_STATES.STATE_DOWN);
+
+      try {
+        await rpcService.executeRPC('testnet', 'qrl_blockNumber', []);
+      } catch {
+        // The upstream failure is expected; only the poller may record it.
+      }
+      const endpoint = healthMonitor.getSnapshot().testnet[0];
+      expect(endpoint.state).to.equal(HEALTH_STATES.STATE_DOWN);
+      expect(endpoint.consecutiveFailures).to.equal(0);
+      expect(stub.callCount).to.equal(3);
+    });
+
     it('falls back to a second endpoint when the first one fails', async () => {
       healthMonitor.__setEndpointsForTesting('testnet', [
         'http://primary.test:8545',

--- a/test/services/rpc/healthMonitor.test.js
+++ b/test/services/rpc/healthMonitor.test.js
@@ -1,4 +1,5 @@
 import * as chai from 'chai';
+import sinon from 'sinon';
 import { healthMonitor, HEALTH_STATES } from '../../../src/services/rpc/healthMonitor.js';
 
 const { expect } = chai;
@@ -6,7 +7,56 @@ const { STATE_UP, STATE_DOWN, STATE_STALLED, STATE_UNKNOWN } = HEALTH_STATES;
 
 describe('healthMonitor', () => {
   afterEach(() => {
+    sinon.restore();
     healthMonitor.__resetForTesting();
+  });
+
+  describe('bounded polling', () => {
+    it('accepts a small valid qrl_blockNumber response', async () => {
+      const fetchStub = sinon
+        .stub(globalThis, 'fetch')
+        .resolves(new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result: '0x2a' })));
+      healthMonitor.__setEndpointsForTesting('testnet', ['http://x:8545']);
+      const ep = healthMonitor.networks.get('testnet')[0];
+
+      await healthMonitor.pollOne('testnet', ep);
+
+      expect(ep.state).to.equal(STATE_UP);
+      expect(ep.lastHeight).to.equal(42);
+      expect(fetchStub.firstCall.args[1].redirect).to.equal('error');
+    });
+
+    it('stores a credential-free category for fetch failures', async () => {
+      const secret = 'HEALTH_SECRET';
+      sinon
+        .stub(globalThis, 'fetch')
+        .rejects(new TypeError(`fetch failed for https://user:${secret}@rpc.invalid/testnet`));
+      healthMonitor.__setEndpointsForTesting('testnet', [
+        `https://user:${secret}@rpc.invalid/testnet`,
+      ]);
+      const ep = healthMonitor.networks.get('testnet')[0];
+
+      await healthMonitor.pollOne('testnet', ep);
+
+      expect(ep.lastError?.message).to.equal('upstream health check failed');
+      expect(healthMonitor.getSnapshot().testnet[0].lastError).not.to.include(secret);
+    });
+
+    it('rejects an oversized health response before parsing it', async () => {
+      sinon.stub(globalThis, 'fetch').resolves(
+        new Response('{}', {
+          headers: { 'Content-Length': String(16 * 1024 + 1) },
+        })
+      );
+      healthMonitor.__setEndpointsForTesting('testnet', ['http://x:8545']);
+      const ep = healthMonitor.networks.get('testnet')[0];
+
+      await healthMonitor.pollOne('testnet', ep);
+
+      expect(ep.consecutiveFailures).to.equal(1);
+      expect(ep.lastError?.message).to.equal('response body too large');
+      expect(ep.state).to.equal(STATE_UNKNOWN);
+    });
   });
 
   describe('orderEndpointsForAttempt', () => {
@@ -88,15 +138,6 @@ describe('healthMonitor', () => {
       expect(ep.state).to.equal(STATE_STALLED);
     });
 
-    it('flips an unknown endpoint to up on a successful real request', () => {
-      healthMonitor.__setEndpointsForTesting('testnet', ['http://x:8545']);
-      const ep = healthMonitor.networks.get('testnet')[0];
-      expect(ep.state).to.equal(STATE_UNKNOWN);
-
-      healthMonitor.applyRequestSuccess('testnet', ep);
-      expect(ep.state).to.equal(STATE_UP);
-    });
-
     it('moves unknown → up on first successful poll even without height advance', () => {
       healthMonitor.__setEndpointsForTesting('testnet', ['http://x:8545']);
       const ep = healthMonitor.networks.get('testnet')[0];
@@ -108,19 +149,16 @@ describe('healthMonitor', () => {
   });
 
   describe('hasHealthyForNetwork', () => {
-    it('returns true for up/unknown/stalled (any non-down state)', () => {
-      // Stalled endpoints still route requests (with stale data), so /health
-      // should report 200 — operators rely on the per-endpoint state field
-      // to spot the stall.
+    it('returns true only for a confirmed-up endpoint', () => {
       healthMonitor.__setEndpointsForTesting('testnet', ['http://x:8545']);
-      expect(healthMonitor.hasHealthyForNetwork('testnet')).to.be.true;
+      expect(healthMonitor.hasHealthyForNetwork('testnet')).to.be.false;
       healthMonitor.__forceStateForTesting('testnet', 'http://x:8545', STATE_STALLED);
-      expect(healthMonitor.hasHealthyForNetwork('testnet')).to.be.true;
+      expect(healthMonitor.hasHealthyForNetwork('testnet')).to.be.false;
       healthMonitor.__forceStateForTesting('testnet', 'http://x:8545', STATE_UP);
       expect(healthMonitor.hasHealthyForNetwork('testnet')).to.be.true;
     });
 
-    it('returns false only when every endpoint is down', () => {
+    it('returns false when every endpoint is down', () => {
       healthMonitor.__setEndpointsForTesting('testnet', ['http://x:8545']);
       healthMonitor.__forceStateForTesting('testnet', 'http://x:8545', STATE_DOWN);
       expect(healthMonitor.hasHealthyForNetwork('testnet')).to.be.false;


### PR DESCRIPTION
## Summary
- fail close the hosted RPC proxy with bounded responses, strict method and parameter admission, trusted proxy CIDRs, and redirect blocking
- bound IPFS and relay memory use, including live Socket.IO egress, atomic channel switching, control-event limits, and role pinning
- separate process liveness from strict RPC readiness and redact parser/upstream credentials from logs and health responses
- harden transaction-history pagination and deployment defaults

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test` (137 passing)
- `npm run build`
- `npm audit --omit=dev --audit-level=moderate` (0 vulnerabilities)
- `npm audit --audit-level=moderate` (0 vulnerabilities)
- `git diff --check`

## Deployment risk
- production binds to loopback unless `LISTEN_HOST` is explicitly set
- `/health` is strict readiness; supervisors must use `/health/live` for liveness
- only `qrl_sendRawTransaction` remains exposed for transaction submission
- relay backpressure may disconnect a slow counterparty after its current transport drain so reconnect can drain bounded buffered payloads