### PR TITLE
release: relay burst delivery fix

### DIFF
--- a/src/relay/channelManager.ts
+++ b/src/relay/channelManager.ts
@@ -441,9 +441,9 @@ class ChannelManager {
     }
 
     // Counterparty is absent or its transport cannot accept a bounded direct
-    // delivery. Retain the payload under the offline budgets. The server
-    // disconnects a backpressured live target so its normal reconnect drains
-    // this buffer instead of leaving an accepted payload parked indefinitely.
+    // delivery. Retain the payload under the offline budgets. A live target
+    // with an in-flight reservation consumes this buffer one message per
+    // transport drain.
     const backpressuredSocketId = targetSocketId ?? undefined;
     const backpressureContext = backpressuredSocketId ? { backpressuredSocketId } : {};
     const otherClientType: ClientType = sender.clientType === 'dapp' ? 'wallet' : 'dapp';
@@ -516,6 +516,40 @@ class ChannelManager {
       this.totalDirectInflightBytes - reservation.sizeBytes
     );
     this.releaseIpBytes(reservation.sourceIp, reservation.sizeBytes);
+  }
+
+  /**
+   * Complete a target's in-flight delivery and reserve its oldest buffered
+   * message for the next transport write. The buffered-to-direct transition
+   * preserves every byte budget while keeping at most one live reservation.
+   */
+  advanceDirectDelivery(socketId: string): RelayPayload | null {
+    const reservation = this.directDeliveries.get(socketId);
+    if (!reservation) return null;
+
+    const { channel } = reservation;
+    const participant = channel.participants.get(socketId);
+    this.releaseDirectDelivery(socketId);
+    if (!participant || channel.terminated) return null;
+
+    const nextIndex = channel.messageBuffer.findIndex(
+      (message) => message.targetClientType === participant.clientType
+    );
+    if (nextIndex < 0) return null;
+
+    const next = channel.messageBuffer.splice(nextIndex, 1)[0];
+    if (!next) return null;
+
+    this.releaseBufferedBytes(channel, next);
+    this.directDeliveries.set(socketId, {
+      channel,
+      sourceIp: next.sourceIp,
+      sizeBytes: next.sizeBytes,
+    });
+    channel.directInflightBytes += next.sizeBytes;
+    this.totalDirectInflightBytes += next.sizeBytes;
+    this.retainIpBytes(next.sourceIp, next.sizeBytes);
+    return next.data;
   }
 
   hasDirectDelivery(socketId: string): boolean {

--- a/src/relay/relayServer.ts
+++ b/src/relay/relayServer.ts
@@ -113,8 +113,10 @@ export function createRelayServer(httpServer: HttpServer): RelayHandle {
     maxHttpBufferSize: MAX_MESSAGE_BYTES,
   });
 
-  const directDrainListeners = new Map<string, { transport: Transport; onDrain: () => void }>();
-  const disconnectAfterDrain = new Set<string>();
+  const directTransportListeners = new Map<
+    string,
+    { transport: Transport; event: 'drain' | 'ready'; listener: () => void }
+  >();
 
   const channelManager = new ChannelManager({
     isSocketActive: (socketId) => io.sockets.sockets.has(socketId),
@@ -124,35 +126,74 @@ export function createRelayServer(httpServer: HttpServer): RelayHandle {
         target?.connected === true &&
         target.conn.readyState === 'open' &&
         target.conn.transport.writable &&
-        !directDrainListeners.has(socketId)
+        !directTransportListeners.has(socketId)
       );
     },
   });
 
   function releaseDirectDelivery(socketId: string): void {
-    const armed = directDrainListeners.get(socketId);
+    const armed = directTransportListeners.get(socketId);
     if (armed) {
-      armed.transport.removeListener('drain', armed.onDrain);
-      directDrainListeners.delete(socketId);
+      armed.transport.removeListener(armed.event, armed.listener);
+      directTransportListeners.delete(socketId);
     }
-    disconnectAfterDrain.delete(socketId);
     channelManager.releaseDirectDelivery(socketId);
+  }
+
+  function waitForDirectReady(socketId: string, transport: Transport): void {
+    const onReady = (): void => {
+      directTransportListeners.delete(socketId);
+      const target = io.sockets.sockets.get(socketId);
+      if (!target?.connected || target.conn.readyState !== 'open') {
+        channelManager.releaseDirectDelivery(socketId);
+        return;
+      }
+
+      // Engine.IO's own ready listener runs first and can consume the newly
+      // writable transport for an existing control packet. Wait for its next
+      // ready cycle while the relay's reservation remains fully accounted.
+      if (!target.conn.transport.writable) {
+        waitForDirectReady(socketId, target.conn.transport);
+        return;
+      }
+
+      // Arm the next drain before moving an accepted buffered message into
+      // the single direct reservation. All checks and the promotion happen in
+      // one synchronous turn, so a failed arm leaves the message buffered for
+      // reconnect.
+      if (!armDirectDelivery(socketId)) {
+        channelManager.releaseDirectDelivery(socketId);
+        target.disconnect(true);
+        return;
+      }
+
+      const nextPayload = channelManager.advanceDirectDelivery(socketId);
+      if (!nextPayload) {
+        releaseDirectDelivery(socketId);
+        return;
+      }
+
+      target.volatile.emit('message', nextPayload);
+    };
+    directTransportListeners.set(socketId, { transport, event: 'ready', listener: onReady });
+    transport.once('ready', onReady);
   }
 
   function armDirectDelivery(socketId: string): boolean {
     const target = io.sockets.sockets.get(socketId);
     if (!target?.connected || target.conn.readyState !== 'open') return false;
     const transport = target.conn.transport;
-    if (!transport.writable || directDrainListeners.has(socketId)) return false;
+    if (!transport.writable || directTransportListeners.has(socketId)) return false;
 
     const onDrain = (): void => {
-      directDrainListeners.delete(socketId);
-      channelManager.releaseDirectDelivery(socketId);
-      if (disconnectAfterDrain.delete(socketId)) {
-        io.sockets.sockets.get(socketId)?.disconnect(true);
-      }
+      directTransportListeners.delete(socketId);
+
+      // Engine.IO emits drain before making websocket and WebTransport
+      // writable again. Polling also waits for the next poll request. Keep the
+      // completed reservation accounted until that transport emits ready.
+      waitForDirectReady(socketId, transport);
     };
-    directDrainListeners.set(socketId, { transport, onDrain });
+    directTransportListeners.set(socketId, { transport, event: 'drain', listener: onDrain });
     transport.once('drain', onDrain);
     return true;
   }
@@ -451,9 +492,7 @@ export function createRelayServer(httpServer: HttpServer): RelayHandle {
 
       if (result.backpressuredSocketId !== undefined) {
         const slowTarget = io.sockets.sockets.get(result.backpressuredSocketId);
-        if (channelManager.hasDirectDelivery(result.backpressuredSocketId)) {
-          disconnectAfterDrain.add(result.backpressuredSocketId);
-        } else {
+        if (!channelManager.hasDirectDelivery(result.backpressuredSocketId)) {
           slowTarget?.disconnect(true);
         }
       }
@@ -606,8 +645,7 @@ export function createRelayServer(httpServer: HttpServer): RelayHandle {
     clearInterval(rateLimitCleanupTimer);
     activeSocketsByIp.clear();
     rateLimits.clear();
-    for (const socketId of directDrainListeners.keys()) releaseDirectDelivery(socketId);
-    disconnectAfterDrain.clear();
+    for (const socketId of directTransportListeners.keys()) releaseDirectDelivery(socketId);
     channelManager.destroy();
     metrics.activeChannels.set(0);
     metrics.bufferedMessages.set(0);

--- a/test/relay/relay.test.js
+++ b/test/relay/relay.test.js
@@ -884,7 +884,49 @@ describe('Relay Server', function () {
   });
 
   describe('live egress budgets', () => {
-    it('bounds a stalled target and drains buffered work through reconnect', async () => {
+    it('delivers back-to-back ACK and ORIGINATOR_INFO without disconnecting', async () => {
+      const relay = await startRelay();
+      const dapp = await connect(relay.port);
+      const wallet = await connect(relay.port);
+      try {
+        await joinChannel(dapp, 'handshake-burst', 'dapp');
+        await joinChannel(wallet, 'handshake-burst', 'wallet');
+
+        const received = [];
+        const bothMessages = new Promise((resolve, reject) => {
+          const timer = setTimeout(
+            () => reject(new Error('Timeout waiting for handshake burst')),
+            2000
+          );
+          wallet.on('message', (message) => {
+            received.push(message);
+            if (received.length === 2) {
+              clearTimeout(timer);
+              resolve(received);
+            }
+          });
+        });
+
+        const [ackResult, originatorInfoResult] = await Promise.all([
+          sendMessage(dapp, 'handshake-burst', { type: 'ACK' }),
+          sendMessage(dapp, 'handshake-burst', { type: 'ORIGINATOR_INFO' }),
+        ]);
+
+        expect(ackResult.success).to.equal(true);
+        expect(originatorInfoResult.success).to.equal(true);
+        expect((await bothMessages).map((payload) => payload.message.type)).to.deep.equal([
+          'ACK',
+          'ORIGINATOR_INFO',
+        ]);
+        expect(wallet.connected).to.equal(true);
+      } finally {
+        await disconnect(dapp);
+        await disconnect(wallet);
+        relay.cleanup();
+      }
+    });
+
+    it('bounds a stalled target and resumes buffered work on drain', async () => {
       const relay = await startRelay({
         RELAY_MAX_BUFFERED_BYTES_PER_CHANNEL: 1800,
         RELAY_MAX_BUFFERED_BYTES_PER_IP: 1800,
@@ -892,7 +934,6 @@ describe('Relay Server', function () {
       });
       const dapp = await connect(relay.port);
       const wallet = await connect(relay.port);
-      let replacement;
       try {
         await joinChannel(dapp, 'live-egress-budget', 'dapp');
         await joinChannel(wallet, 'live-egress-budget', 'wallet');
@@ -923,19 +964,47 @@ describe('Relay Server', function () {
         expect(stats.totalDirectInflightBytes + stats.totalBufferedBytes).to.be.at.most(1800);
         expect(target.conn.writeBuffer.length).to.equal(0);
 
-        const disconnected = waitForEvent(wallet, 'disconnect');
+        const resumed = waitForEvent(wallet, 'message');
         transport.send = originalSend;
         transport.emit('drain');
+        transport.emit('ready');
+        expect(relay.channelManager.getStats().totalBufferedMessages).to.equal(1);
         transport.writable = true;
         transport.emit('ready');
+
+        expect((await resumed).message).to.equal(`${payload}2`);
+        expect(wallet.connected).to.equal(true);
+        expect(relay.channelManager.getStats().totalBufferedMessages).to.equal(0);
+      } finally {
+        await disconnect(dapp);
+        await disconnect(wallet);
+        relay.cleanup();
+      }
+    });
+
+    it('disconnects an idle unwritable target so reconnect drains its buffer', async () => {
+      const relay = await startRelay();
+      const dapp = await connect(relay.port);
+      const wallet = await connect(relay.port);
+      let replacement;
+      try {
+        await joinChannel(dapp, 'idle-backpressure', 'dapp');
+        await joinChannel(wallet, 'idle-backpressure', 'wallet');
+        await new Promise((resolve) => setImmediate(resolve));
+
+        const target = relay.io.sockets.sockets.get(wallet.id);
+        target.conn.transport.writable = false;
+        const disconnected = waitForEvent(target, 'disconnect');
+
+        const result = await sendMessage(dapp, 'idle-backpressure', 'queued-ciphertext');
+        expect(result).to.deep.include({ success: true, buffered: true });
         await disconnected;
-        expect(relay.channelManager.getStats().totalDirectInflightBytes).to.equal(0);
 
         replacement = await connect(relay.port);
-        const rejoined = await joinChannel(replacement, 'live-egress-budget', 'wallet');
+        const rejoined = await joinChannel(replacement, 'idle-backpressure', 'wallet');
         expect(rejoined.success).to.equal(true);
         expect(rejoined.bufferedMessages).to.have.length(1);
-        expect(rejoined.bufferedMessages[0].message).to.equal(`${payload}2`);
+        expect(rejoined.bufferedMessages[0].message).to.equal('queued-ciphertext');
       } finally {
         await disconnect(dapp);
         await disconnect(wallet);
@@ -1240,6 +1309,44 @@ describe('Relay Server', function () {
 
         cm.leave('wallet-socket', 'leave-inflight');
         expect(cm.getStats().totalDirectInflightBytes).to.equal(reserved);
+
+        cm.releaseDirectDelivery('wallet-socket');
+        expect(cm.getStats().totalDirectInflightBytes).to.equal(0);
+      } finally {
+        cm.destroy();
+      }
+    });
+
+    it('moves one buffered message into the live reservation after each drain', () => {
+      const cm = new ChannelManager({ canSocketReceive: () => true });
+      try {
+        cm.join('burst-accounting', 'dapp-socket', 'dapp');
+        cm.join('burst-accounting', 'wallet-socket', 'wallet');
+        const first = {
+          id: 'burst-accounting',
+          clientType: 'dapp',
+          message: { type: 'ACK' },
+        };
+        const second = {
+          id: 'burst-accounting',
+          clientType: 'dapp',
+          message: { type: 'ORIGINATOR_INFO' },
+        };
+
+        expect(cm.routeMessage('burst-accounting', 'dapp-socket', first).buffered).to.equal(false);
+        expect(cm.routeMessage('burst-accounting', 'dapp-socket', second).buffered).to.equal(true);
+
+        const retainedBefore = cm.getStats();
+        expect(retainedBefore.totalDirectInflightBytes).to.be.greaterThan(0);
+        expect(retainedBefore.totalBufferedBytes).to.be.greaterThan(0);
+
+        expect(cm.advanceDirectDelivery('wallet-socket')).to.deep.equal(second);
+        const retainedAfter = cm.getStats();
+        expect(retainedAfter.totalBufferedMessages).to.equal(0);
+        expect(retainedAfter.totalBufferedBytes).to.equal(0);
+        expect(retainedAfter.totalDirectInflightBytes).to.equal(
+          Buffer.byteLength(JSON.stringify(second))
+        );
 
         cm.releaseDirectDelivery('wallet-socket');
         expect(cm.getStats().totalDirectInflightBytes).to.equal(0);


### PR DESCRIPTION
## Summary
- promote the bounded relay burst delivery fix from dev
- preserve live transport accounting while draining buffered messages
- keep connected wallet sessions alive across ACK and ORIGINATOR_INFO bursts

## Validation
- CI passed on the feature PR
- dev auto-deploy verified at the exact merge commit
- dev health and logs verified
- live two-client ACK and ORIGINATOR_INFO burst passed in order without disconnect

## Runtime impact
- production backend process restarts once through the existing deployment webhook
- no environment or data migration changes

## Known risks
- transport-specific timing remains covered by unit/integration tests and the live dev smoke test