### PR TITLE
fix(relay): confirm durable channel tombstones

### DIFF
--- a/src/relay/channelManager.ts
+++ b/src/relay/channelManager.ts
@@ -304,18 +304,18 @@ class ChannelManager {
    * The tombstone is retained for TOMBSTONE_TTL_MS and is excluded from the
    * active-channel admission count so it cannot block new channels.
    */
-  close(channelId: string): void {
+  close(channelId: string): boolean {
     const channel = this.channels.get(channelId);
     // Only mark an existing channel. Never fabricate a tombstone for an
     // unknown channelId: a non-existent channel is already dead (a re-joining
     // peer sees no participants anyway), and creating one would let an
     // attacker fill memory with tombstones that bypass the channel cap.
-    if (!channel) return;
+    if (!channel) return false;
     // Idempotent: a channel can only be tombstoned once. Without this a
     // repeated close() (or a re-join->close loop on the same id) would push
     // duplicate entries into terminatedOrder and the FIFO eviction would then
     // flush out legitimate tombstones.
-    if (channel.terminated) return;
+    if (channel.terminated) return false;
     channel.terminated = true;
     channel.terminatedAt = Date.now();
     channel.lastActivity = Date.now();
@@ -341,6 +341,7 @@ class ChannelManager {
         this.channels.delete(oldest);
       }
     }
+    return true;
   }
 
   /**

--- a/src/relay/relayServer.ts
+++ b/src/relay/relayServer.ts
@@ -575,34 +575,43 @@ export function createRelayServer(httpServer: HttpServer): RelayHandle {
       const requested = isRecord(payload) ? payload.channelId : undefined;
       const channelId = typeof requested === 'string' && requested ? requested : currentChannelId;
 
-      if (isValidChannelId(channelId)) {
-        // Authorize: only an actual participant may terminate the channel.
-        // leave() returns the participant record (and null if this socket is
-        // not in the channel), so it doubles as the membership check. This
-        // blocks an attacker from closing arbitrary channels by guessing a
-        // channelId, and from creating tombstones for channels they were
-        // never part of (the close() below only marks an existing channel).
-        void socket.leave(channelId);
-        const participant = channelManager.leave(socket.id, channelId);
-
-        if (participant) {
-          channelManager.close(channelId);
-          refreshBufferMetrics();
-
-          // Tell a currently-connected counterparty this was an explicit
-          // close, distinct from a transient 'disconnect'.
-          socket.to(channelId).emit('participants_changed', {
-            event: 'close',
-            clientType: participant.clientType,
-          });
-
-          if (currentChannelId === channelId) {
-            currentChannelId = null;
-          }
-        }
+      if (!isValidChannelId(channelId)) {
+        callback?.({
+          success: false,
+          terminated: false,
+          error: 'Channel close was not confirmed',
+        });
+        return;
       }
 
-      callback?.({ success: true });
+      // Only an actual participant may terminate the channel. Return the same
+      // failure for unknown channels and non-participants so the ack cannot be
+      // mistaken for a durable tombstone or used as a channel-existence probe.
+      const participant = channelManager.leave(socket.id, channelId);
+      if (!participant || !channelManager.close(channelId)) {
+        callback?.({
+          success: false,
+          terminated: false,
+          error: 'Channel close was not confirmed',
+        });
+        return;
+      }
+
+      void socket.leave(channelId);
+      refreshBufferMetrics();
+
+      // Tell a currently-connected counterparty this was an explicit close,
+      // distinct from a transient disconnect.
+      socket.to(channelId).emit('participants_changed', {
+        event: 'close',
+        clientType: participant.clientType,
+      });
+
+      if (currentChannelId === channelId) {
+        currentChannelId = null;
+      }
+
+      callback?.({ success: true, terminated: true });
     });
 
     /**

--- a/test/relay/relay.test.js
+++ b/test/relay/relay.test.js
@@ -94,6 +94,13 @@ function sendMessage(socket, channelId, message, clientType = 'dapp') {
   });
 }
 
+/** Explicitly close a channel and return the relay's durable-close ack. */
+function closeChannel(socket, channelId) {
+  return new Promise((resolve) => {
+    socket.emit('close_channel', { channelId }, (resp) => resolve(resp));
+  });
+}
+
 /** Wait for a specific event with a timeout. */
 function waitForEvent(socket, event, timeoutMs = 2000) {
   return new Promise((resolve, reject) => {
@@ -1081,8 +1088,9 @@ describe('Relay Server', function () {
     it('close_channel marks a tombstone surfaced on a later re-join', async () => {
       const dapp = await connect(relay.port);
       await joinChannel(dapp, 'tombstone-ch', 'dapp');
-      await new Promise((resolve) => {
-        dapp.emit('close_channel', { channelId: 'tombstone-ch' }, () => resolve());
+      expect(await closeChannel(dapp, 'tombstone-ch')).to.deep.equal({
+        success: true,
+        terminated: true,
       });
       await disconnect(dapp);
 
@@ -1092,6 +1100,37 @@ describe('Relay Server', function () {
       expect(resp.success).to.be.true;
       expect(resp.terminated).to.be.true;
       await disconnect(dapp2);
+    });
+
+    it('fails closed when no participant-backed tombstone was created', async () => {
+      const dapp = await connect(relay.port);
+      const wallet = await connect(relay.port);
+      const attacker = await connect(relay.port);
+      await joinChannel(dapp, 'close-authz', 'dapp');
+      await joinChannel(wallet, 'close-authz', 'wallet');
+
+      const expectedFailure = {
+        success: false,
+        terminated: false,
+        error: 'Channel close was not confirmed',
+      };
+      expect(await closeChannel(attacker, 'close-authz')).to.deep.equal(expectedFailure);
+      expect(await closeChannel(attacker, 'close-unknown')).to.deep.equal(expectedFailure);
+      expect(await closeChannel(attacker, '')).to.deep.equal(expectedFailure);
+
+      const received = waitForEvent(wallet, 'message');
+      expect((await sendMessage(dapp, 'close-authz', 'still-live')).success).to.equal(true);
+      expect((await received).message).to.equal('still-live');
+
+      expect(await closeChannel(dapp, 'close-authz')).to.deep.equal({
+        success: true,
+        terminated: true,
+      });
+      expect(await closeChannel(dapp, 'close-authz')).to.deep.equal(expectedFailure);
+
+      await disconnect(dapp);
+      await disconnect(wallet);
+      await disconnect(attacker);
     });
 
     it('notifies a connected counterparty of an explicit close', async () => {


### PR DESCRIPTION
## Summary

- return a confirmed tombstone acknowledgement only after an authorized participant closes an existing channel
- fail closed for invalid, unknown, unauthorized, and repeated close requests
- expose the close result from ChannelManager for protocol-level verification

## Validation

- npm run format:check
- npm run lint
- npm run typecheck
- npm test (141 passing)
- npm run build
- git diff --check
- outgoing opsec scan

## Runtime impact

Existing authorized clients continue receiving success. Hardened SDK clients can require `success: true` and `terminated: true` before treating relay teardown as durable.